### PR TITLE
Refactored SingleLineDataConverter class; fixed broken helper method in DataConverterTest

### DIFF
--- a/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
@@ -195,12 +195,15 @@ public class DataConverterTest {
         final String expectedLogWithoutPID = "{\"timestamp\":\"Mar 12 12:01:02\",\"hostname\":\"server4\",\"program\":\"snort\",\"processid\":null,\"message\":\"Ports to decode telnet on: 21 23 25 119\"}\n";
         verifyDataConversion(converter, logWithoutPID.getBytes(), expectedLogWithoutPID.getBytes()); 
     }
-    
-    private void verifyDataConversion(IDataConverter converter, byte[] dataBin, byte[] expectedBin) throws Exception {
-        ByteBuffer data = ByteBuffer.wrap(dataBin);
-        ByteBuffer res = converter.convert(data);
-        byte[] resBin = new byte[res.remaining()];
-        res.get(resBin);
-        Assert.assertEquals(resBin, expectedBin);
+
+    private void verifyDataConversion(
+            final IDataConverter converter,
+            final byte[] bytes,
+            final byte[] expected) throws Exception {
+        final ByteBuffer data = ByteBuffer.wrap(bytes);
+        final ByteBuffer result = converter.convert(data);
+        final byte[] actual = new byte[result.remaining()];
+        result.get(actual);
+        Assert.assertTrue(Arrays.equals(actual, expected));
     }
 }


### PR DESCRIPTION
This PR refactors `SingleLineDataConverter` and address whether the converter should be responsible for trimming each line it converts. That is, the converter not only assumes the conversion of the data provided and (to some degree) its format, but also what rules to apply during conversion. That is, trimming each line and omitting (possibly) empty lines. A future feature might be to make the `SingleLineDataConverter` configurable by allowing the user to set flags around line processing (ex: `handleTrimmingAutomatically`, `handleEmptyStringsAutomatically`). **Note**, these flags would be set to `true` by default and would require the user to override them. (I can add this feature, just let me know).

A fix for the helper method `verifyDataConversion` in `DataConverterTest` is also addressed in this PR. That is, the assertion `Assert.assertEquals(byteArr0, byteArr1);` is checking for obj reference equality and not the content in the byte array. For example, the following test fails:
```
byte[] ARRAY1234_0 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
byte[] ARRAY1234_1 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
Assert.assertEquals(ARRAY1234_0, ARRAY1234_1);
```
but when changing the test to use `Arrays.equals()` 
```
byte[] ARRAY1234_0 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
byte[] ARRAY1234_1 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
Assert.assertTrue(Arrays.equals(ARRAY1234_0, ARRAY1234_1));
```
the test now passes as the content is checked, not the reference.