### PR TITLE
Initial support for installing the agent on Ubuntu hosts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ out/
 
 # Ignore Mac DS_Store files
 .DS_Store
+
+# Junk working files
+ant_build
+dependencies
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The **Amazon Kinesis Agent** is a stand-alone Java software application that off
 After you've downloaded the code from GitHub, you can install the Amazon Kinesis Agent with the following command:
 
 ```sh
+# Optionally, you can set DEBUG=1 in your environment to enable massively
+# verbose output of the script
 sudo ./setup --install
 ```
 
@@ -74,7 +76,13 @@ sudo ./setup --uninstall
 
 ## Building from Source
 
-The installation done by the setup script is only tested on **Red Hat Enterprise Linux** version 7 or later and **Amazon Linux AMI** version 2015.09 or later. For other distributions or platforms, you can build the Java project with the following command:
+The installation done by the setup script is only tested on the following OS Disributions:
+
+  * **Red Hat Enterprise Linux** version 7 or later
+  * **Amazon Linux AMI** version 2015.09 or later
+  * **Ubuntu Linux** version 12.04 or later
+
+For other distributions or platforms, you can build the Java project with the following command:
 
 ```sh
 sudo ./setup --build

--- a/bin/aws-kinesis-agent.RedHat
+++ b/bin/aws-kinesis-agent.RedHat
@@ -45,6 +45,8 @@ LOG_DIR=/var/log/$DAEMON_NAME
 [[ -d $STATE_HOME ]] || mkdir -p $STATE_HOME
 MUTEXFILE=$STATE_HOME/mutex
 SHUTDOWN_TIME=11   #10 second default value in AgentConfiguration.java, +1 second buffer
+LOGLEVEL=${LOGLEVEL:-INFO}
+ARGS=${ARGS:-}
 
 INITLOGFILE=/tmp/$DAEMON_NAME.`date '+%Y%m%d%H%M%S'`.initlog
 
@@ -68,7 +70,7 @@ do_start () {
   
   (
     flock -w 10 -x 9
-    DAEMON_NAME=$DAEMON_NAME nohup runuser $AGENT_USER -s /bin/sh -c "$DAEMON_EXEC $@" > $INITLOGFILE 2>&1 &
+    DAEMON_NAME=$DAEMON_NAME nohup runuser $AGENT_USER -s /bin/sh -c "$DAEMON_EXEC -L $LOGLEVEL $ARGS $@" > $INITLOGFILE 2>&1 &
 
     pid=$!
     echo $pid > $PIDFILE

--- a/bin/aws-kinesis-agent.Ubuntu
+++ b/bin/aws-kinesis-agent.Ubuntu
@@ -1,0 +1,103 @@
+#! /usr/bin/env bash
+
+### BEGIN INIT INFO
+# Provides:          aws-kinesis-agent
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Daemon for Amazon Kinesis Agent.
+# Description:       This script is responsible for running Amazon Kinesis Agent
+#                    as a daemon.
+### END INIT INFO
+
+# get init functions: status()
+[ -e /lib/lsb/init-functions ] && . /lib/lsb/init-functions
+
+#set -x
+DAEMON_NAME=aws-kinesis-agent
+NAME=$DAEMON_NAME  # ubuntu compatibility
+AGENT_USER=aws-kinesis-agent-user
+PIDFILE=/var/run/$DAEMON_NAME.pid
+LOG_DIR=/var/log/$DAEMON_NAME
+SHUTDOWN_TIME=11   #10 second default value in AgentConfiguration.java, +1 second buffer
+INITLOGFILE=/tmp/$DAEMON_NAME.`date '+%Y%m%d%H%M%S'`.initlog
+
+# This script is in /etc/rc.d/init.d/ and the executable is in /usr/bin
+BASEDIR=${BASEDIR%/}
+DAEMON_EXEC=$BASEDIR/usr/bin/start-$DAEMON_NAME
+LOGLEVEL=${LOGLEVEL:-INFO}
+ARGS=${ARGS:-}
+RETVAL=0
+
+# load any configs/environment from /etc/defaults/<name>
+[ -e /etc/defaults/$DAEMON_NAME ] && . /etc/defaults/$DAEMON_NAME
+
+# Export the settings
+do_start () {
+  # Return
+  #   0 if daemon has been started
+  #   1 if daemon was already running
+  #   other if daemon could not be started or a failure occured
+  start-stop-daemon --start \
+          --quiet \
+          --background \
+          --make-pidfile \
+          --pidfile $PIDFILE \
+          --chuid $AGENT_USER \
+          --startas $DAEMON_EXEC -- \
+                -L $LOGLEVEL \
+                $ARGS
+}
+
+do_stop () {
+  # Return
+  #   0 if daemon has been stopped
+  #   1 if daemon was already stopped
+  #   other if daemon could not be stopped or a failure occurred
+  start-stop-daemon --stop \
+          --quiet \
+          --retry=TERM/$SHUTDOWN_TIME/KILL/5 \
+          --pidfile $PIDFILE \
+          --oknodo  \
+          && rm -f ${PIDFILE}
+}
+
+
+
+command=$1
+shift
+case "$command" in
+  start)
+    log_daemon_msg "Starting $DAEMON_NAME"
+    do_start
+
+    case "$?" in
+      0) log_end_msg 0 ;;
+      1) log_warning_msg "already started"
+         log_end_msg 0 ;;
+      *) log_end_msg 1 ;;
+    esac
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DAEMON_NAME"
+    do_stop
+
+    case "$?" in
+      0) log_end_msg 0 ;;
+      *) log_end_msg 1 ;;
+    esac
+    ;;
+  restart)
+    $0 stop
+    $0 start
+    ;;
+  status)
+    status_of_proc -p $PIDFILE $DAEMON_NAME $NAME
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+exit $RETVAL

--- a/build.xml
+++ b/build.xml
@@ -13,8 +13,8 @@
     <property name="build.dependencies" location="dependencies" />
 
     <path id="classpath">
-        <fileset dir="/usr/share/java" includes="**/*.jar" />
         <fileset dir="${build.dependencies}" includes="**/*.jar" />
+        <fileset dir="/usr/share/java" includes="**/*.jar" />
     </path>
 
     <target name="get-java-version">

--- a/setup
+++ b/setup
@@ -1,19 +1,45 @@
 #! /usr/bin/env bash
 
+# If we have an error, bail out!
+set -e
+
+# If we're debugging, be really loudly verbose
+[[ ! -z $DEBUG ]] && set -x
+
+# Attempt to load up the /etc/lsb-release file to determine our OS. If none is
+# found, we default our settings to RHEL/Amazon Linux as the original behavior
+# of this script intended.
+dist=RedHat
+[[ -f /etc/lsb-release ]] && dist=Ubuntu
+
+# Tell the user what OS we detected
+echo "Detected OS Distro: ${dist}"
+
 # Make sure only root can run our script
 if [ "$(id -u)" != "0" ]; then
  echo "This script must be run as root" >&2
  exit 1
 fi
 
+# Based on the OS, determine which commands we'll be calling to install/manage
+# certain things
+case "$dist" in
+  Ubuntu)
+    install_package="apt-get install -y"
+    init_dir=/etc/init.d
+    sysconfig_dir=/etc/defaults ;;
+  *)
+    install_package="yum install -y"
+    init_dir=/etc/rc.d/init.d
+    sysconfig_dir=/etc/sysconfig ;;
+esac
+
 daemon_name=aws-kinesis-agent
 agent_user_name=aws-kinesis-agent-user
 bin_dir=/usr/bin
 cron_dir=/etc/cron.d
-sysconfig_dir=/etc/sysconfig
 config_dir=/etc/aws-kinesis
 jar_dir=/usr/share/${daemon_name}/lib
-init_dir=/etc/rc.d/init.d
 dependencies_dir=./dependencies
 log_dir=/var/log/${daemon_name}
 state_dir=/var/run/${daemon_name}
@@ -39,11 +65,25 @@ download_jar() {
   prefix="http://search.maven.org/remotecontent?filepath="
   path=${1//.//}
   jar_name=$artifact_id-$version.jar
+  tmp_dest=$(mktemp -u)
+  jar_dest=$dependencies_dir/$jar_name
   url=${prefix}${path}/${artifact_id}/${version}/${jar_name}
-  [[ -f ${dependencies_dir}/${jar_name} ]] || wget -P ${dependencies_dir} $url
+
+  # file exists? then don't download it!
+  [[ -f ${jar_dest} ]] && return
+
+  # download the file to a temp location, then if move it here if successful
+  echo "Downloading $jar_name ($url)..."
+  wget -q -P ${dependencies_dir} $url -O ${tmp_dest} && \
+    mv ${tmp_dest} ${jar_dest}
+
+  # Purge our temp file regardless of the status here
+  rm -f ${tmp_dest}
 }
 
 download_dependencies() {
+  which ant > /dev/null || $install_package ant
+
   install -d ${dependencies_dir}
   
   echo "Downloading dependencies ..."
@@ -91,11 +131,10 @@ do_uninstall () {
   fi
 
   # remove the service from system services
-  chkconfig --list $daemon_name > /dev/null 2>&1
-  if [ $? == 0 ]; then
-    echo "Removing $daemon_name from system services..."
-    sudo chkconfig --del $daemon_name
-  fi
+  case "$dist" in
+    Ubuntu) update-rc.d -f $daemon_name remove > /dev/null 2>&1 || true ;;
+    *) chkconfig --del $daemon_name > /dev/null 2>&1 || true ;;
+  esac
   
   # remove the jars and config files
   rm -rf ${state_dir}
@@ -105,8 +144,7 @@ do_uninstall () {
   rm -f ${bin_dir}/start-${daemon_name}
   
   # remove the user for starting the agent
-  user_id=$(id -u $agent_user_name > /dev/null 2>&1)
-  [[ $? == 0 ]] && userdel $agent_user_name
+  userdel $agent_user_name > /dev/null || true
   
   # remove sysconfig
   rm -f ${sysconfig_dir}/${daemon_name}
@@ -142,13 +180,13 @@ do_install () {
   install -m755 ./bin/${daemon_name}-babysit ${bin_dir}
   install -m644 ./${dependencies_dir}/* ${jar_dir}
   install -m644 ./ant_build/lib/* ${jar_dir}
-  install -m755 ./bin/${daemon_name} ${init_dir}
+  install -m755 ./bin/${daemon_name}.${dist} ${init_dir}/${daemon_name}
   install -m644 ./support/${daemon_name}.cron ${cron_dir}/${daemon_name}
   install -m644 ./support/${daemon_name}.sysconfig ${sysconfig_dir}/${daemon_name}
   
   # add a user for starting the agent
-  user_id=$(id -u $agent_user_name > /dev/null 2>&1)
-  [[ $? == 0 ]] || useradd -c "Streaming Data Agent" -r $agent_user_name
+  id -u $agent_user_name > /dev/null 2>&1 || \
+    useradd -c "Streaming Data Agent" -r $agent_user_name
   usermod -L $agent_user_name
   
   # change the owner of log files and checkpoint files to the user
@@ -161,7 +199,10 @@ do_install () {
   echo "Configuration details:"
   cat "${config_file}"
   
-  /sbin/chkconfig --add $daemon_name
+  case "$dist" in
+    Ubuntu) update-rc.d $daemon_name defaults ;;
+    *) chkconfig --add $daemon_name ;;
+  esac
   
   echo "Amazon Kinesis Agent is installed successfully."
   echo "To start the $daemon_name service, run:"

--- a/support/aws-kinesis-agent.sysconfig
+++ b/support/aws-kinesis-agent.sysconfig
@@ -1,4 +1,7 @@
 # Set AWS credentials for accessing Amazon Kinesis Stream and Amazon Kinesis Firehose
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_DEFAULT_REGION=
+#
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=
+# ARGS=""
+# LOGLEVEL="INFO"


### PR DESCRIPTION
This commit refactors the setup script so that its a little more
idempotent, easier to read the output of the wget downloads, and now
supports Ubuntu as well as RHEL/AmazonLinux.

We also create a new Ubuntu-specific startup script thats vastly simpler
than the RedHat/Amazon Linux script.

@rayzhu19, this is a WIP ... It functions on my local dev box, but we havn't done any production-style deploys yet with it. What are your thoughts on the initial work though?