### PR TITLE
Fixes an oversight in setup

### DIFF
--- a/setup
+++ b/setup
@@ -63,7 +63,7 @@ download_jar() {
   artifact_id=$2
   version=$3
   prefix="http://search.maven.org/remotecontent?filepath="
-  path=${1//.//}
+  path=${group_id//.//}
   jar_name=$artifact_id-$version.jar
   tmp_dest=$(mktemp -u)
   jar_dest=$dependencies_dir/$jar_name


### PR DESCRIPTION
group_id gets assigned but not used.  Used it in place of positional $1.