### PR TITLE
fix permissions issue in RedHat startup script

### DIFF
--- a/bin/aws-kinesis-agent.RedHat
+++ b/bin/aws-kinesis-agent.RedHat
@@ -42,7 +42,7 @@ AGENT_USER=aws-kinesis-agent-user
 PIDFILE=/var/run/$DAEMON_NAME.pid
 STATE_HOME=/var/run/$DAEMON_NAME
 LOG_DIR=/var/log/$DAEMON_NAME
-[[ -d $STATE_HOME ]] || mkdir -p $STATE_HOME
+[[ -d $STATE_HOME ]] || install -o $AGENT_USER -g $AGENT_USER -d $STATE_HOME
 MUTEXFILE=$STATE_HOME/mutex
 SHUTDOWN_TIME=11   #10 second default value in AgentConfiguration.java, +1 second buffer
 LOGLEVEL=${LOGLEVEL:-INFO}


### PR DESCRIPTION
Running `mkdir -p` resulted in the `/var/run/aws-kinesis-agent`
directory being created as root, but the aws-kinesis-agent-user user
needs to have permissions to that directory. This change results in
`aws-kinesis-agent-user` being the owner of the directory, instead of
root.