### PR TITLE
Add support to IAM Roles for Tasks & update aws-sdk to version 1.11.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
 
     <properties>
-        <aws-java-sdk.version>1.10.26</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.28</aws-java-sdk.version>
     </properties>
 
     <dependencies>

--- a/setup
+++ b/setup
@@ -87,7 +87,7 @@ download_dependencies() {
   install -d ${dependencies_dir}
   
   echo "Downloading dependencies ..."
-  aws_java_sdk_version="1.10.26"
+  aws_java_sdk_version="1.11.28"
   
   remote_mvn_pkg="com.amazonaws:aws-java-sdk-core:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-kinesis:${aws_java_sdk_version} \

--- a/src/com/amazon/kinesis/streaming/agent/AgentAWSCredentialsProviderChain.java
+++ b/src/com/amazon/kinesis/streaming/agent/AgentAWSCredentialsProviderChain.java
@@ -18,6 +18,7 @@ import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.ContainerCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 public class AgentAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
@@ -25,6 +26,7 @@ public class AgentAWSCredentialsProviderChain extends AWSCredentialsProviderChai
         super(new AgentAWSCredentialsProvider(config),
                 new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
+                new ContainerCredentialsProvider(),
                 new ProfileCredentialsProvider(),
                 new InstanceProfileCredentialsProvider());
     }


### PR DESCRIPTION
Add support to IAM Roles for Tasks including ContainerCredentialsProvider.
Also update aws-sdk to latest version (1.11.28) to have it working.