### PR TITLE
Fix/directory permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+        </dependency>
+        <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-core</artifactId>
           <version>${aws-java-sdk.version}</version>

--- a/src/com/amazon/kinesis/streaming/agent/Agent.java
+++ b/src/com/amazon/kinesis/streaming/agent/Agent.java
@@ -53,7 +53,7 @@ public class Agent extends AbstractIdleService implements IHeartbeatProvider {
         String configFile = opts.getConfigFile();
         AgentConfiguration config = tryReadConfigurationFile(Paths.get(opts.getConfigFile()));
         Path logFile = opts.getLogFile() != null ? Paths.get(opts.getLogFile()) : (config != null ? config.logFile() : null);
-        String logLevel = opts.getLogLevel() != null ? opts.getLogLevel() : (config != null ? config.logLevel() : null);
+        String logLevel = config != null ? config.logLevel() : (opts.getLogLevel() != null ? opts.getLogLevel() : null );
         int logMaxBackupFileIndex = (config != null ? config.logMaxBackupIndex() : -1);
         long logMaxFileSize = (config != null ? config.logMaxFileSize() : -1L);
         Logging.initialize(logFile, logLevel, logMaxBackupFileIndex, logMaxFileSize);

--- a/src/com/amazon/kinesis/streaming/agent/Agent.java
+++ b/src/com/amazon/kinesis/streaming/agent/Agent.java
@@ -52,7 +52,9 @@ public class Agent extends AbstractIdleService implements IHeartbeatProvider {
         AgentOptions opts = AgentOptions.parse(args);
         String configFile = opts.getConfigFile();
         AgentConfiguration config = tryReadConfigurationFile(Paths.get(opts.getConfigFile()));
-        Path logFile = opts.getLogFile() != null ? Paths.get(opts.getLogFile()) : (config != null ? config.logFile() : null);
+
+        //Path logFile = opts.getLogFile() != null ? Paths.get(opts.getLogFile()) : (config != null ? config.logFile() : null);
+        Path logFile = config != null ? config.logFile() : (opts.getLogFile() != null ? Paths.get(opts.getLogFile()) : null);
         String logLevel = config != null ? config.logLevel() : (opts.getLogLevel() != null ? opts.getLogLevel() : null );
         int logMaxBackupFileIndex = (config != null ? config.logMaxBackupIndex() : -1);
         long logMaxFileSize = (config != null ? config.logMaxFileSize() : -1L);

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
@@ -47,7 +47,6 @@ import com.amazon.kinesis.streaming.agent.Logging;
  */
 public class CSVToJSONDataConverter implements IDataConverter {
 
-    protected final Logger logger;
     private static String FIELDS_KEY = "customFieldNames";
     private static String DELIMITER_KEY = "delimiter";
     private final List<String> fieldNames;
@@ -56,7 +55,6 @@ public class CSVToJSONDataConverter implements IDataConverter {
 
     
     public CSVToJSONDataConverter(Configuration config) {
-        this.logger = Logging.getLogger(getClass());
         fieldNames = config.readList(FIELDS_KEY, String.class);
         delimiter = config.readString(DELIMITER_KEY, ",");
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
@@ -78,7 +76,7 @@ public class CSVToJSONDataConverter implements IDataConverter {
             try {
                 recordMap.put(fieldNames.get(i), columns[i]);
             } catch (ArrayIndexOutOfBoundsException e) {
-                logger.debug("Null field in CSV detected");
+                Logging.getLogger(getClass()).debug("Null field in CSV detected");
                 recordMap.put(fieldNames.get(i), null);
             } catch (Exception e) {
                 throw new DataConversionException("Unable to create the column map", e);

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
@@ -25,6 +25,8 @@ import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionEx
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IJSONPrinter;
 import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactory;
+import org.slf4j.Logger;
+import com.amazon.kinesis.streaming.agent.Logging;
 
 /**
  * Convert a CSV record into JSON record.
@@ -44,14 +46,17 @@ import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactor
  *
  */
 public class CSVToJSONDataConverter implements IDataConverter {
-    
+
+    protected final Logger logger;
     private static String FIELDS_KEY = "customFieldNames";
     private static String DELIMITER_KEY = "delimiter";
     private final List<String> fieldNames;
     private final String delimiter;
     private final IJSONPrinter jsonProducer;
+
     
     public CSVToJSONDataConverter(Configuration config) {
+        this.logger = Logging.getLogger(getClass());
         fieldNames = config.readList(FIELDS_KEY, String.class);
         delimiter = config.readString(DELIMITER_KEY, ",");
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
@@ -73,6 +78,7 @@ public class CSVToJSONDataConverter implements IDataConverter {
             try {
                 recordMap.put(fieldNames.get(i), columns[i]);
             } catch (ArrayIndexOutOfBoundsException e) {
+                logger.debug("Null field in CSV detected");
                 recordMap.put(fieldNames.get(i), null);
             } catch (Exception e) {
                 throw new DataConversionException("Unable to create the column map", e);

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
@@ -71,12 +71,11 @@ public class LogToJSONDataConverter implements IDataConverter {
         Map<String, Object> recordMap;
 
         try {
-            logger.debug("Parsing Line: " + dataStr);
             recordMap = logParser.parseLogRecord(dataStr, fields);
         } catch (LogParsingException e) {
             // ignore the record if a LogParsingException is thrown
             // the record is filtered out in this case
-            logger.debug("Exception while parsing " + dataStr + ": " + e.toString());
+            logger.debug("Exception while parsing log: " + dataStr + ": " + e.toString());
             return null;
         }
 

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
@@ -1,14 +1,14 @@
 /*
  * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Amazon Software License (the "License").
- * You may not use this file except in compliance with the License. 
+ * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/asl/
- *  
- * or in the "license" file accompanying this file. 
- * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 package com.amazon.kinesis.streaming.agent.processing.processors;
@@ -26,10 +26,12 @@ import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IJSONPrinter;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.ILogParser;
 import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactory;
+import org.slf4j.Logger;
+import com.amazon.kinesis.streaming.agent.Logging;
 
 /**
  * Parse the log entries from log file, and convert the log entries into JSON.
- * 
+ *
  * Configuration of this converter looks like:
  * {
  *     "optionName": "LOGTOJSON",
@@ -37,17 +39,19 @@ import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactor
  *     "matchPattern": "OPTIONAL_REGEX",
  *     "customFieldNames": [ "column1", "column2", ... ]
  * }
- * 
+ *
  * @author chaocheq
  *
  */
 public class LogToJSONDataConverter implements IDataConverter {
-    
+
+    protected final Logger logger;
     private List<String> fields;
     private ILogParser logParser;
     private IJSONPrinter jsonProducer;
-    
+
     public LogToJSONDataConverter(Configuration config) {
+        this.logger = Logging.getLogger(getClass());
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
         logParser = ProcessingUtilsFactory.getLogParser(config);
         if (config.containsKey(ProcessingUtilsFactory.CUSTOM_FIELDS_KEY)) {
@@ -58,22 +62,24 @@ public class LogToJSONDataConverter implements IDataConverter {
     @Override
     public ByteBuffer convert(ByteBuffer data) throws DataConversionException {
         String dataStr = ByteBuffers.toString(data, StandardCharsets.UTF_8);
-        
+
         // Preserve the NEW_LINE at the end of the JSON record
         if (dataStr.endsWith(NEW_LINE)) {
             dataStr = dataStr.substring(0, (dataStr.length() - NEW_LINE.length()));
         }
-        
+
         Map<String, Object> recordMap;
-        
+
         try {
+            logger.debug("Parsing Line: " + dataStr);
             recordMap = logParser.parseLogRecord(dataStr, fields);
         } catch (LogParsingException e) {
             // ignore the record if a LogParsingException is thrown
             // the record is filtered out in this case
+            logger.debug("Exception while parsing " + dataStr + ": " + e.toString());
             return null;
         }
-        
+
         String dataJson = jsonProducer.writeAsString(recordMap) + NEW_LINE;
         return ByteBuffer.wrap(dataJson.getBytes(StandardCharsets.UTF_8));
     }

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
@@ -45,13 +45,11 @@ import com.amazon.kinesis.streaming.agent.Logging;
  */
 public class LogToJSONDataConverter implements IDataConverter {
 
-    protected final Logger logger;
     private List<String> fields;
     private ILogParser logParser;
     private IJSONPrinter jsonProducer;
 
     public LogToJSONDataConverter(Configuration config) {
-        this.logger = Logging.getLogger(getClass());
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
         logParser = ProcessingUtilsFactory.getLogParser(config);
         if (config.containsKey(ProcessingUtilsFactory.CUSTOM_FIELDS_KEY)) {
@@ -75,7 +73,7 @@ public class LogToJSONDataConverter implements IDataConverter {
         } catch (LogParsingException e) {
             // ignore the record if a LogParsingException is thrown
             // the record is filtered out in this case
-            logger.debug("Exception while parsing log: " + dataStr + ": " + e.toString());
+            Logging.getLogger(getClass()).debug("Exception while parsing log: " + dataStr + ": " + e.toString());
             return null;
         }
 

--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -23,14 +23,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.amazon.kinesis.streaming.agent.Agent;
 import com.amazon.kinesis.streaming.agent.Logging;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.slf4j.Logger;
 
 /**
  * Specification of the file(s) to be tailed.

--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -41,7 +41,6 @@ public class SourceFile {
     @Getter private final Path directory;
     @Getter private final Path filePattern;
     private final PathMatcher pathMatcher;
-    final Logger logger = Logging.getLogger(getClass());
 
     public SourceFile(FileFlow<?> flow, String filePattern) {
         this.flow = flow;
@@ -122,7 +121,7 @@ public class SourceFile {
         //check the permissions of every level in the directory path
         for(Path level : dir.toAbsolutePath()){
             if(!Files.isReadable(level)){
-                logger.warn("Permission Denied: Agent user unable to read " + dir.toString());
+                Logging.getLogger(getClass()).warn("Permission Denied: Agent user unable to read " + dir.toString());
             }
         }
     }

--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -23,11 +23,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazon.kinesis.streaming.agent.Agent;
+import com.amazon.kinesis.streaming.agent.Logging;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
 
 /**
  * Specification of the file(s) to be tailed.
@@ -38,6 +41,7 @@ public class SourceFile {
     @Getter private final Path directory;
     @Getter private final Path filePattern;
     private final PathMatcher pathMatcher;
+    final Logger logger = Logging.getLogger(Agent.class);
 
     public SourceFile(FileFlow<?> flow, String filePattern) {
         this.flow = flow;
@@ -114,6 +118,13 @@ public class SourceFile {
     private void validateDirectory(Path dir) {
         Preconditions.checkArgument(dir != null, "Directory component is empty!");
         // TODO: validate that the directory component has no glob characters
+
+        //check the permissions of every level in the directory path
+        for(Path level : dir.toAbsolutePath()){
+            if(!Files.isReadable(level)){
+                logger.warn("Permission Denied: Agent user unable to read " + dir.toString());
+            }
+        }
     }
     
     /**

--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -41,7 +41,7 @@ public class SourceFile {
     @Getter private final Path directory;
     @Getter private final Path filePattern;
     private final PathMatcher pathMatcher;
-    final Logger logger = Logging.getLogger(Agent.class);
+    final Logger logger = Logging.getLogger(getClass());
 
     public SourceFile(FileFlow<?> flow, String filePattern) {
         this.flow = flow;


### PR DESCRIPTION
Previously, permissions issues with directories of tracked files would not be reported and instead display the following message while the agent was running:

"Tailer Progress: Tailer has parsed 0 records (0 bytes), transformed 0 records, skipped 0 records, and has successfully sent 0 records to destination."

This pull request adds warnings for each directory with permissions issues at agent startup. These warnings look like this:

"[WARN] Permission Denied: Agent user unable to read (directory-name)"

This should allow for easier troubleshooting of issues like #58 

I've also changed the order in which the log file location is chosen, prioritizing the config file over the default options. This should allow for easier customization of the agent
