### PR TITLE
EC2 metadata processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
           <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-ec2</artifactId>
+          <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
           <version>2.6.3</version>

--- a/setup
+++ b/setup
@@ -98,6 +98,7 @@ download_dependencies() {
                   com.amazonaws:aws-java-sdk-kinesis:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-cloudwatch:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-sts:${aws_java_sdk_version} \
+                  com.amazonaws:aws-java-sdk-ec2:${aws_java_sdk_version} \
                   com.fasterxml.jackson.core:jackson-annotations:2.6.3 \
                   com.fasterxml.jackson.core:jackson-core:2.6.3 \
                   com.fasterxml.jackson.core:jackson-databind:2.6.3 \

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
@@ -45,7 +45,8 @@ import com.amazon.kinesis.streaming.agent.Logging;
  *
  * Configuration of this converter looks like:
  * {
- *     "optionName": "ADDEC2METADATA"
+ *     "optionName": "ADDEC2METADATA",
+ *     "logFormat": "RFC3339SYSLOG"
  * }
  *
  * @author buholzer

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
@@ -19,6 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Date;
+import java.text.SimpleDateFormat;
 
 import com.amazon.kinesis.streaming.agent.ByteBuffers;
 import com.amazon.kinesis.streaming.agent.config.Configuration;
@@ -123,7 +125,9 @@ public class AddEC2MetadataConverter implements IDataConverter {
       metadata.put("accountId", info.getAccountId());
       metadata.put("amiId", info.getImageId());
       metadata.put("region", info.getRegion());
-      metadata.put("metadataTimestamp", metadataTimestamp);
+      metadata.put("metadataTimestamp",
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+              .format(new Date(metadataTimestamp)));
 
       final AmazonEC2 ec2 = AmazonEC2ClientBuilder.defaultClient();
       DescribeTagsResult result = ec2.describeTags(

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.kinesis.streaming.agent.processing.processors;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+import com.amazon.kinesis.streaming.agent.ByteBuffers;
+import com.amazon.kinesis.streaming.agent.config.Configuration;
+import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionException;
+import com.amazon.kinesis.streaming.agent.processing.exceptions.LogParsingException;
+import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
+import com.amazon.kinesis.streaming.agent.processing.interfaces.IJSONPrinter;
+import com.amazon.kinesis.streaming.agent.processing.interfaces.ILogParser;
+import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactory;
+import com.amazonaws.util.EC2MetadataUtils;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.DescribeTagsRequest;
+import com.amazonaws.services.ec2.model.DescribeTagsResult;
+import com.amazonaws.services.ec2.model.TagDescription;
+import com.amazonaws.services.ec2.model.Filter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import com.amazon.kinesis.streaming.agent.Logging;
+
+/**
+ * Parse the log entries from log file, and convert the log entries into JSON.
+ *
+ * Configuration of this converter looks like:
+ * {
+ *     "optionName": "ADDEC2METADATA"
+ * }
+ *
+ * @author buholzer
+ *
+ */
+public class AddEC2MetadataConverter implements IDataConverter {
+
+  private static final Logger LOGGER = Logging.getLogger(AddEC2MetadataConverter.class);
+  private ILogParser logParser;
+  private IJSONPrinter jsonProducer;
+  private Map<String, Object> metadata;
+
+  public AddEC2MetadataConverter(Configuration config) {
+      jsonProducer = ProcessingUtilsFactory.getPrinter(config);
+      logParser = ProcessingUtilsFactory.getLogParser(config);
+      refreshEC2Metadata();
+  }
+
+  @Override
+  public ByteBuffer convert(ByteBuffer data) throws DataConversionException {
+
+    if (metadata == null || metadata.isEmpty()) {
+      LOGGER.warn("Unable to append metadata, no metadata found");
+      return data;
+    }
+
+    String dataStr = ByteBuffers.toString(data, StandardCharsets.UTF_8);
+
+    ObjectMapper mapper = new ObjectMapper();
+    TypeReference<LinkedHashMap<String,Object>> typeRef = 
+      new TypeReference<LinkedHashMap<String,Object>>() {};
+
+    LinkedHashMap<String,Object> dataObj = null;
+    try {
+      dataObj = mapper.readValue(dataStr, typeRef);
+    } catch (Exception ex) {
+      throw new DataConversionException("Error converting json source data to map", ex);
+    }
+
+    // Appending EC2 metadata
+    dataObj.putAll(metadata);
+
+    String dataJson = jsonProducer.writeAsString(dataObj) + NEW_LINE;
+    return ByteBuffer.wrap(dataJson.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void refreshEC2Metadata() {
+    LOGGER.info("Refreshing EC2 Metadata");
+
+    try {
+      EC2MetadataUtils.InstanceInfo info = EC2MetadataUtils.getInstanceInfo();
+
+      metadata = new LinkedHashMap<String, Object>();
+      metadata.put("privateIp", info.getPrivateIp());
+      metadata.put("availabilityZone", info.getAvailabilityZone());
+      metadata.put("instanceId", info.getInstanceId());
+      metadata.put("instanceType", info.getInstanceType());
+      metadata.put("accountId", info.getAccountId());
+      metadata.put("amiId", info.getImageId());
+      metadata.put("region", info.getRegion());
+
+      final AmazonEC2 ec2 = AmazonEC2ClientBuilder.defaultClient();
+      DescribeTagsResult result = ec2.describeTags(
+        new DescribeTagsRequest().withFilters(
+          new Filter().withName("resource-id").withValues(info.getInstanceId())));
+      List<TagDescription> tags = result.getTags();
+
+      Map<String, Object> metadataTags = new LinkedHashMap<String, Object>();
+      for (TagDescription tag : tags) {
+        metadataTags.put(tag.getKey().toLowerCase(), tag.getValue());
+      }
+      metadata.put("tags", metadataTags);
+    } catch (Exception ex) {
+      LOGGER.warn("Error while updating ec2 metadata - " + ex.getMessage() + ", ignoring");
+    }
+  }
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/AddEC2MetadataConverter.java
@@ -110,7 +110,7 @@ public class AddEC2MetadataConverter implements IDataConverter {
   }
 
   private void refreshEC2Metadata() {
-    LOGGER.info("Refreshing EC2 Metadata");
+    LOGGER.info("Refreshing EC2 metadata");
 
     metadataTimestamp = System.currentTimeMillis();
     
@@ -141,7 +141,7 @@ public class AddEC2MetadataConverter implements IDataConverter {
       }
       metadata.put("tags", metadataTags);
     } catch (Exception ex) {
-      LOGGER.warn("Error while updating ec2 metadata - " + ex.getMessage() + ", ignoring");
+      LOGGER.warn("Error while updating EC2 metadata - " + ex.getMessage() + ", ignoring");
     }
   }
 }

--- a/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
@@ -27,6 +27,7 @@ import com.amazon.kinesis.streaming.agent.processing.processors.CSVToJSONDataCon
 import com.amazon.kinesis.streaming.agent.processing.processors.LogToJSONDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.SingleLineDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.AddMetadataConverter;
+import com.amazon.kinesis.streaming.agent.processing.processors.AddEC2MetadataConverter;
 
 /**
  * The factory to create: 
@@ -42,6 +43,7 @@ public class ProcessingUtilsFactory {
     
     public static enum DataConversionOption {
     	ADDMETADATA,
+	ADDEC2METADATA,
         SINGLELINE,
         CSVTOJSON,
         LOGTOJSON,
@@ -117,6 +119,8 @@ public class ProcessingUtilsFactory {
         switch (option) {
 	    case ADDMETADATA:
 		return new AddMetadataConverter(config);
+	    case ADDEC2METADATA:
+		return new AddEC2MetadataConverter(config);
             case SINGLELINE:
                 return new SingleLineDataConverter();
             case CSVTOJSON:


### PR DESCRIPTION
EC2 metadata processor retrieves metadata from the EC2 instance metadata service and retrieves the instance tags via a EC2 describe tags request. The metadata is then merged with the json data. 

The metadata is requested on startup and updated on the next log request when the metadataTimestamp + metadataTTL is in the past, metadataTTL default is 60 minutes.

Security - The instance role needs to have EC2 describe tags IAM permissions.

The following data is merged to all the log entries:
- privateIp
- availabilityZone
- instanceId
- instanceType
- accountId
- amiId (imageId)
- region
- metadataTimestamp (iso timestamp of metadata update)

Sample usage:
```
"flows": [{
	"filePattern": "/var/log/syslog",
	"deliveryStream": "your-system-log-stream",
	"dataProcessingOptions": [{
	"optionName": "LOGTOJSON",
	"logFormat": "RFC3339SYSLOG"
}, {
	"optionName": "ADDEC2METADATA",
	"logFormat": "RFC3339SYSLOG"
}]
```