### PR TITLE
Agent config directory for flow configurations

### DIFF
--- a/setup
+++ b/setup
@@ -44,6 +44,7 @@ agent_user_name=aws-kinesis-agent-user
 bin_dir=/usr/bin
 cron_dir=/etc/cron.d
 config_dir=/etc/aws-kinesis
+config_flow_dir=/etc/aws-kinesis/agent.d
 jar_dir=/usr/share/${daemon_name}/lib
 dependencies_dir=./dependencies
 log_dir=/var/log/${daemon_name}
@@ -179,6 +180,7 @@ do_install () {
   do_build
   
   install -d ${config_dir}
+  install -d ${config_flow_dir}
   install -d ${jar_dir}
   install -d ${init_dir}
   install -d ${cron_dir}

--- a/src/com/amazon/kinesis/streaming/agent/Agent.java
+++ b/src/com/amazon/kinesis/streaming/agent/Agent.java
@@ -141,42 +141,42 @@ public class Agent extends AbstractIdleService implements IHeartbeatProvider {
         }
     }
     
-private static AgentConfiguration readConfigurationDirectory(AgentConfiguration agentConfiguration) {
-    final String DEFAULT_CONFIG_DIRECTORY = "/etc/aws-kinesis/agent.d/";
-    final Logger logger = Logging.getLogger(Agent.class);
+    private static AgentConfiguration readConfigurationDirectory(AgentConfiguration agentConfiguration) {
+        final String DEFAULT_CONFIG_DIRECTORY = "/etc/aws-kinesis/agent.d/";
+        final Logger logger = Logging.getLogger(Agent.class);
 
-    File configDir = new File(DEFAULT_CONFIG_DIRECTORY);
+        File configDir = new File(DEFAULT_CONFIG_DIRECTORY);
 
-    if (!configDir.exists() || !configDir.isDirectory()) return agentConfiguration;
+        if (!configDir.exists() || !configDir.isDirectory()) return agentConfiguration;
 
-    // Add flows from the main configuration
-    List<Configuration> flows = new LinkedList();
-    flows.addAll((List<Configuration>) agentConfiguration.getConfigMap().get("flows"));
+        // Add flows from the main configuration
+        List<Configuration> flows = new LinkedList();
+        flows.addAll((List<Configuration>) agentConfiguration.getConfigMap().get("flows"));
 
-    // Read all configuration files
-    File[] configFiles = configDir.listFiles();
+        // Read all configuration files
+        File[] configFiles = configDir.listFiles();
 
-    Configuration config = null;
-    
-    for (File file : configFiles) {
-        if (file.isFile()) {
-            try {
-                logger.info("Reading flow configuration from file: " + file.getName());
-                config = Configuration.get(new FileInputStream(file));
-            } catch (Exception ex) {
-                logger.warn("Error reading configuration file, ignoring - " + file.getName());
+        Configuration config = null;
+
+        for (File file : configFiles) {
+            if (file.isFile()) {
+                try {
+                    logger.info("Reading flow configuration from file: " + file.getName());
+                    config = Configuration.get(new FileInputStream(file));
+                } catch (Exception ex) {
+                    logger.warn("Error reading configuration file, ignoring - " + file.getName());
+                }
+                if (config.containsKey("flows")) flows.addAll((List<Configuration>) config.getConfigMap().get("flows"));
             }
-            if (config.containsKey("flows")) flows.addAll((List<Configuration>) config.getConfigMap().get("flows"));
         }
-    }
 
-    logger.info("Found " + flows.size() + " configured flow(s)");
+        logger.info("Found " + flows.size() + " configured flow(s)");
 
-    // Append flows
-    HashMap<String, Object> newConfig = new HashMap<String,Object>(agentConfiguration.getConfigMap());
-    newConfig.put("flows", flows);
-    return new AgentConfiguration(newConfig);
-}    
+        // Append flows
+        HashMap<String, Object> newConfig = new HashMap<String,Object>(agentConfiguration.getConfigMap());
+        newConfig.put("flows", flows);
+        return new AgentConfiguration(newConfig);
+    }    
 
     private final AgentContext agentContext;
     private final HeartbeatService heartbeat;

--- a/src/com/amazon/kinesis/streaming/agent/Agent.java
+++ b/src/com/amazon/kinesis/streaming/agent/Agent.java
@@ -163,10 +163,11 @@ public class Agent extends AbstractIdleService implements IHeartbeatProvider {
                 try {
                     logger.info("Reading flow configuration from file: " + file.getName());
                     config = Configuration.get(new FileInputStream(file));
+                    if ((config != null) && config.containsKey("flows"))
+                        flows.addAll((List<Configuration>) config.getConfigMap().get("flows"));
                 } catch (Exception ex) {
                     logger.warn("Error reading configuration file, ignoring - " + file.getName());
                 }
-                if (config.containsKey("flows")) flows.addAll((List<Configuration>) config.getConfigMap().get("flows"));
             }
         }
 


### PR DESCRIPTION
The agent config directory for flow configurations allows configuration management systems to add additional flows dynamically without having to edit the main configuration in place.

Similar to other linux services, this change creates a .d at /etc/aws-kinesis/agent.d/ where additional flow configurations can be added in multiple files. The agent will read the main configuration file and then append the multiple flow configurations in /etc/aws-kinesis/agent.d/.
The flow configurations have the exact same structure as the main agent configuration, but only the flow items will be appended to the final configuration, everything else is ignored.

Below an example of a flow configuration for MongoDB:
/etc/aws-kinesis/agent.d/mongodb_log.json
```
{
  "flows": [
    {
      "filePattern": "/var/log/mongodb/mongod.log",
      "initialPosition": "END_OF_FILE",
      "deliveryStream": "your-log-stream",
      "dataProcessingOptions": [
        {
          "optionName": "LOGTOJSON",
          "logFormat": "RFC3339MONGODB"
        },
        {
          "optionName": "ADDEC2METADATA",
          "logFormat": "RFC3339SYSLOG"
        }
      ]
    }
  ]
}
```
