### PR TITLE
Update LogToJSONDataConverter.java to display LogParsingException

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import com.amazon.kinesis.streaming.agent.ByteBuffers;
+import com.amazon.kinesis.streaming.agent.Logging;
 import com.amazon.kinesis.streaming.agent.config.Configuration;
 import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionException;
 import com.amazon.kinesis.streaming.agent.processing.exceptions.LogParsingException;

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/LogToJSONDataConverter.java
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-
+import org.slf4j.Logger;
 import com.amazon.kinesis.streaming.agent.ByteBuffers;
 import com.amazon.kinesis.streaming.agent.config.Configuration;
 import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionException;
@@ -46,6 +46,7 @@ public class LogToJSONDataConverter implements IDataConverter {
     private List<String> fields;
     private ILogParser logParser;
     private IJSONPrinter jsonProducer;
+    private final Logger LOGGER=Logging.getLogger(getClass());
     
     public LogToJSONDataConverter(Configuration config) {
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
@@ -69,6 +70,7 @@ public class LogToJSONDataConverter implements IDataConverter {
         try {
             recordMap = logParser.parseLogRecord(dataStr, fields);
         } catch (LogParsingException e) {
+            LOGGER.debug(e.getMessage() + ".Failed log entry -" + dataStr);
             // ignore the record if a LogParsingException is thrown
             // the record is filtered out in this case
             return null;


### PR DESCRIPTION
In case of LogParsingException,agent captures LogParsingException but doesnot display it in the log file.
e.g.
agent.json : - 
{
	"cloudwatch.emitMetrics": true,
	"cloudwatch.endpoint": "monitoring.us-west-2.amazonaws.com",
	"kinesis.endpoint": "kinesis.us-west-2.amazonaws.com",
	"firehose.endpoint": "firehose.us-west-2.amazonaws.com",
	"checkpointFile": "/tmp/aws-kinesis-agent-checkpoints/main.log",
	"awsAccessKeyId": "",
	"awsSecretAccessKey": "",
	"flows": [{
		"filePattern": "/*.csv",
		"deliveryStream": "",
		"initialPosition": "START_OF_FILE",
		"dataProcessingOptions": [{
			"optionName": "LOGTOJSON",
			"logFormat": "COMMONAPACHELOG",
			"customFieldNames": ["PreparationContentId",
			"JournalTitle",
			"PublisherName",
			"Volume",
			"Issue",
			"Year",
			"SelfURI",
			"FirstPage",
			"ArticleID",
			"ISSN",
			"BundleName",
			"TimeStamp"],
			"matchPattern": "\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\",\"([^\"]*)\""
		}]
Log File : - 

"20479059","Berichte zur Wissenschaftsgeschichte","","40","3","2017","","271","10.1002/bewi.201701817","0170-6233"
"20479059","Berichte zur Wissenschaftsgeschichte","","40","3","2017","","225","10.1002/bewi.201701824","0170-6233","BEWI40.3_bewi201701824","2017-09-01T00:00:00Z"

In this case ,agent will process 1 record and skip first record.But it will just not display what is wrong with the data.

In this case, error will be "Invalid log entry given the entry pattern",but it would take me a while to figure out what's wrong with the data when the data is huge in numbers.

Thanks,
Kiran
 