### PR TITLE
Configuration for file footer pattern

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/AbstractParser.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/AbstractParser.java
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import lombok.Getter;
 
@@ -58,6 +60,7 @@ public abstract class AbstractParser<R extends IRecord> implements IParser<R> {
     FileChannel currentFileChannel;
     private long currentFileChannelOffset = -1;
     private int headerLinesToSkip;
+    private Pattern fileFooterPattern;
 
     @VisibleForTesting
     ByteBuffer currentBuffer;
@@ -172,6 +175,7 @@ public abstract class AbstractParser<R extends IRecord> implements IParser<R> {
                 currentFileChannel = currentFile.getChannel();
                 currentFileChannelOffset = currentFileChannel.position();
                 headerLinesToSkip = currentFileChannelOffset == 0 ? flow.getSkipHeaderLines() : 0;
+                fileFooterPattern = flow.getFileFooterPattern();
                 return true;
             } else {
                 return false;
@@ -465,6 +469,16 @@ public abstract class AbstractParser<R extends IRecord> implements IParser<R> {
 
     private R buildRecord(int offset, int length) {
         ByteBuffer data = ByteBuffers.getPartialView(currentBuffer, offset, length);
+
+        //Backward compatible with config that does not have this option
+        if(fileFooterPattern != null){
+            final Matcher fileFooterMatcher = fileFooterPattern.matcher(data.asCharBuffer());
+            if(fileFooterMatcher.matches()){
+                stopParsing("End of file reached, file footer pattern matched");
+                return null;
+            }
+        }
+
         ++recordsFromCurrentBuffer;
         Preconditions.checkNotNull(currentBufferFile);
         

--- a/src/com/amazon/kinesis/streaming/agent/tailing/FileFlow.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/FileFlow.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -57,6 +58,7 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
     public static final String INITIAL_POSITION_KEY = "initialPosition";
     public static final String DEFAULT_TRUNCATED_RECORD_TERMINATOR = String.valueOf(Constants.NEW_LINE);
     public static final String CONVERSION_OPTION_KEY = "dataProcessingOptions";
+    public static final String FILE_FOOTER_PATTERN = "fileFooterPattern"; //If a line matches this pattern it stops processing the file
 
     @Getter protected final AgentContext agentContext;
     @Getter protected final SourceFile sourceFile;
@@ -74,6 +76,7 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
     @Getter protected final long retryMaxBackoffMillis;
     @Getter protected final int publishQueueCapacity;
     @Getter protected final IDataConverter dataConverter;
+    @Getter protected final Pattern fileFooterPattern;
 
     protected FileFlow(AgentContext context, Configuration config) {
         super(config);
@@ -105,6 +108,10 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
         
         String pattern = readString("multiLineStartPattern", null);
         recordSplitter = Strings.isNullOrEmpty(pattern) ? new SingleLineSplitter() : new RegexSplitter(pattern);
+
+        String footerPattern = readString(FILE_FOOTER_PATTERN, null);
+
+        fileFooterPattern = Strings.isNullOrEmpty(footerPattern)? null : Pattern.compile(footerPattern);
 
         String terminatorConfig = readString("truncatedRecordTerminator", DEFAULT_TRUNCATED_RECORD_TERMINATOR);
         if (terminatorConfig == null || terminatorConfig.getBytes(StandardCharsets.UTF_8).length >= getMaxRecordSizeBytes()) {
@@ -190,6 +197,7 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
     protected abstract long getDefaultRetryInitialBackoffMillis();
     protected abstract long getDefaultRetryMaxBackoffMillis();
     protected abstract int getDefaultPublishQueueCapacity();
+
 
     public static enum InitialPosition {
         START_OF_FILE,


### PR DESCRIPTION
There are some cases where we want to stop parsing a file when we reach the end as indicated by a footer. The footer could be something like "File Closed" or "EOF". This would save resources in cases where there are a lot of small files. 
This would be configured in the fileFlow as follows: 

    "fileFooterPattern" : "^EOF$"

The pull request is just a small proof of concept to see if you think it is a good feature to have and if it works architecturally. Unit tests and documentation are to follow. 