### PR TITLE
add notrim,escape_new_line to singleline mode

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/SingleLineDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/SingleLineDataConverter.java
@@ -13,12 +13,15 @@
  */
 package com.amazon.kinesis.streaming.agent.processing.processors;
 
+import java.util.List;
+import java.util.ArrayList;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.amazon.kinesis.streaming.agent.ByteBuffers;
+import com.amazon.kinesis.streaming.agent.config.Configuration;
 import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionException;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
 
@@ -28,26 +31,41 @@ import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
  * 
  * Configuration looks like:
  * 
- * { "optionName": "SINGLELINE" }
+ * {
+ *     "optionName": "SINGLELINE",
+ *     "parseOptions": [ "NO_TRIM", "ESCAPE_NEW_LINE" ]
+ * }
  * 
  * @author chaocheq
  *
  */
 public class SingleLineDataConverter implements IDataConverter {
     
+    private final boolean noTrim;
+    private final boolean escapeNewLine;
+
+    public SingleLineDataConverter(Configuration config) {
+        List<String> parseOptions = config.readList("parseOptions", String.class, new ArrayList<String>());
+        noTrim = parseOptions.contains("NO_TRIM") ? true : false;
+        escapeNewLine = parseOptions.contains("ESCAPE_NEW_LINE") ? true : false;
+    }
+
     @Override
     public ByteBuffer convert(ByteBuffer data) throws DataConversionException {
         String dataStr = ByteBuffers.toString(data, StandardCharsets.UTF_8);
         String[] lines = dataStr.split(NEW_LINE);
-        for (int i = 0; i < lines.length; i++) {
-            // FIXME: Shall we trim each line?
-            lines[i] = lines[i].trim();
+
+        if (!noTrim) {
+            for (int i = 0; i < lines.length; i++) {
+                lines[i] = lines[i].trim();
+            }
         }
-        
-        String dataRes = StringUtils.join(lines) + NEW_LINE;
+
+        String delimiter = escapeNewLine ? "\\\\n" : "";
+        String dataRes = StringUtils.join(lines, delimiter) + NEW_LINE;
         return ByteBuffer.wrap(dataRes.getBytes(StandardCharsets.UTF_8));
     }
-    
+
     @Override
     public String toString() {
         return getClass().getSimpleName();

--- a/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
@@ -122,7 +122,7 @@ public class ProcessingUtilsFactory {
             case ADDEC2METADATA:
                 return new AddEC2MetadataConverter(config);
             case SINGLELINE:
-                return new SingleLineDataConverter();
+                return new SingleLineDataConverter(config);
             case CSVTOJSON:
                 return new CSVToJSONDataConverter(config);
             case LOGTOJSON:


### PR DESCRIPTION
This is a solution for [YAML log(dnstap)](https://gist.github.com/edmonds/5772879#file-dnstap-yaml).

New option "parseOptions"(not required) is added to "SINGLELINE". 
This option provides 2 features.
- NO_TRIM: stop each line trim.
- ESCAPE_NEW_LINE: escape new line "\\\\n" (like json)

Configuration sample
```
      "dataProcessingOptions": [
        {
          "optionName": "SINGLELINE",
          "parseOptions": ["ESCAPE_NEW_LINE"]
        }
      ]
```

