### PR TITLE
Remove redundant file footer pattern noop regex

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/AbstractParser.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/AbstractParser.java
@@ -470,7 +470,7 @@ public abstract class AbstractParser<R extends IRecord> implements IParser<R> {
     private R buildRecord(int offset, int length) {
         ByteBuffer data = ByteBuffers.getPartialView(currentBuffer, offset, length);
         
-        if (fileFooterPattern != null && fileFooterPattern.pattern() != FileFlow.NO_MATCH_REGEX.pattern()) {
+        if (fileFooterPattern != null) {
             final Matcher fileFooterMatcher = fileFooterPattern.matcher(data.asCharBuffer());
             if(fileFooterMatcher.matches()) {
                 stopParsing("End of file reached, file footer pattern matched");

--- a/src/com/amazon/kinesis/streaming/agent/tailing/FileFlow.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/FileFlow.java
@@ -59,8 +59,6 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
     public static final String DEFAULT_TRUNCATED_RECORD_TERMINATOR = String.valueOf(Constants.NEW_LINE);
     public static final String CONVERSION_OPTION_KEY = "dataProcessingOptions";
     public static final String FILE_FOOTER_PATTERN = "fileFooterPattern"; //If a line matches this pattern it stops processing the file
-    
-    public static final Pattern NO_MATCH_REGEX = Pattern.compile("^\\b$"); //https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything
 
     @Getter protected final AgentContext agentContext;
     @Getter protected final SourceFile sourceFile;
@@ -113,7 +111,7 @@ public abstract class FileFlow<R extends IRecord> extends Configuration {
         
         String footerPattern = readString(FILE_FOOTER_PATTERN, null);
         
-        fileFooterPattern = Strings.isNullOrEmpty(footerPattern)? NO_MATCH_REGEX : Pattern.compile(footerPattern);
+        fileFooterPattern = Strings.isNullOrEmpty(footerPattern)? null : Pattern.compile(footerPattern);
 
         String terminatorConfig = readString("truncatedRecordTerminator", DEFAULT_TRUNCATED_RECORD_TERMINATOR);
         if (terminatorConfig == null || terminatorConfig.getBytes(StandardCharsets.UTF_8).length >= getMaxRecordSizeBytes()) {


### PR DESCRIPTION
There is no need to for the noop regex if the pattern is null or empty since there is a null check in place