### PR TITLE
Update hardcoded JAVA_HOME path in the build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
 
     <path id="classpath">
         <fileset dir="${build.dependencies}" includes="**/*.jar" />
-        <fileset dir="/usr/share/java" includes="**/*.jar" />
+        <fileset dir="${java.home}" includes="**/*.jar" />
     </path>
 
     <target name="get-java-version">


### PR DESCRIPTION
Most systems already have Java installed, in our case OracleJDK which is a custom path. Because of this, the install of this will fail. This PR is to change hard coded path for java to use the current java home that is running ant. As long as java is in the PATH, this should work assuming its a JDK.