### PR TITLE
Pluggable data converter

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/PluggableDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/PluggableDataConverter.java
@@ -1,0 +1,67 @@
+package com.amazon.kinesis.streaming.agent.processing.processors;
+
+import java.lang.reflect.Constructor;
+import java.nio.ByteBuffer;
+
+import com.amazon.kinesis.streaming.agent.config.Configuration;
+import com.amazon.kinesis.streaming.agent.config.ConfigurationException;
+import com.amazon.kinesis.streaming.agent.processing.exceptions.DataConversionException;
+import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
+
+/**
+ * Parse the log entries using an external pluggable class
+ *
+ * Configuration of this converter looks like:
+ * {
+ *     "optionName": "USINGPLUGGIN",
+ *     "className": "org.example.MyDataConverter"
+ * }
+ *
+ */
+public class PluggableDataConverter implements IDataConverter {
+
+  private final IDataConverter plugginConverter;
+
+  public PluggableDataConverter(Configuration config) throws ConfigurationException {
+    plugginConverter = readPlugginConverter(config);
+  }
+
+  private static IDataConverter readPlugginConverter(Configuration config) throws ConfigurationException {
+    try {
+      return unsafeReadPlugginConverter(config);
+    }
+    catch (ReflectiveOperationException e) {
+      throw new ConfigurationException(e.getMessage(), e);
+    }
+  }
+
+  private static IDataConverter unsafeReadPlugginConverter(Configuration config) throws ReflectiveOperationException {
+
+    final Class<IDataConverter> clazz = readPlugginConverterClass(config);
+
+    for (final Constructor<?> ctor : clazz.getConstructors()) {
+      final Class<?>[] paramTypes = ctor.getParameterTypes();
+      if (paramTypes.length == 1 && paramTypes[0].equals(Configuration.class)) {
+        return (IDataConverter) ctor.newInstance(config);
+      }
+    }
+
+    return clazz.newInstance();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Class<IDataConverter> readPlugginConverterClass(Configuration config) {
+    try {
+      return (Class<IDataConverter>) Class.forName(config.readString("className"));
+    }
+    catch (ClassNotFoundException e) {
+      throw new ConfigurationException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public ByteBuffer convert(ByteBuffer data) throws DataConversionException {
+    return plugginConverter.convert(data);
+  }
+
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
@@ -27,6 +27,7 @@ import com.amazon.kinesis.streaming.agent.processing.processors.AddMetadataConve
 import com.amazon.kinesis.streaming.agent.processing.processors.BracketsDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.CSVToJSONDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.LogToJSONDataConverter;
+import com.amazon.kinesis.streaming.agent.processing.processors.PluggableDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.SingleLineDataConverter;
 
 /**
@@ -47,7 +48,8 @@ public class ProcessingUtilsFactory {
         SINGLELINE,
         CSVTOJSON,
         LOGTOJSON,
-        ADDBRACKETS
+        ADDBRACKETS,
+        USINGPLUGGIN,
     }
     
     public static enum LogFormat {
@@ -129,6 +131,8 @@ public class ProcessingUtilsFactory {
                 return new LogToJSONDataConverter(config);
             case ADDBRACKETS:
                 return new BracketsDataConverter();
+            case USINGPLUGGIN:
+                return new PluggableDataConverter(config);
             default:
                 throw new ConfigurationException(
                         "Specified option is not implemented yet: " + option);


### PR DESCRIPTION
This PR provides the support for a new data conversion option, `USINGPLUGGIN`,  which will load an external java class to delegate the actual task of converting the bytes.

This will enable to easily plug external classes without requiring to modify the amazon source code.

The bare minimum to configure this converted is:

```json
{
  "optionName": "USINGPLUGGIN",
  "className": "org.example.MyDataConverter"
}
```

Optionally the `PluggableDataConverter` exposes such configuration when the external class contains a constructor with a single configuration parameter. 

```java
package org.example;
class MyExampleConverter implements IDataConverter {
  public MyExampleConverter (Configuration config) {
    // use config.readString() as usually
  }
}
```

Finally, please let me know your thoughts and if you think something is missing on this PR. 