### PR TITLE
Fixes unknown source problem in exception stacktraces.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -35,7 +35,7 @@
 
     <target name="compile" depends="check-java-version, init">
         <mkdir dir="${build.private}" />
-        <javac source="1.7" target="1.7" includeantruntime="false" classpathref="classpath" srcdir="${src.dir}" destdir="${build.private}" />
+        <javac source="1.7" target="1.7" includeantruntime="false" classpathref="classpath" srcdir="${src.dir}" destdir="${build.private}" debug="true" />
         <property name="src.agent.path" value="com/amazon/kinesis/streaming/agent" />
         <copy todir="${build.private}/${src.agent.path}" failonerror="true">
             <fileset dir="${src.dir}/${src.agent.path}" excludes="**/*.java" />


### PR DESCRIPTION
Please see the below stack trace. Code compiled with ant does not show line numbers.

```
com.fasterxml.jackson.databind.JsonMappingException: No content to map due to end-of-input
 at [Source: [B@578469d; line: 1, column: 1]
    at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148)
    at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3781)
    at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3721)
    at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:2294)
    at com.amazonaws.http.JsonErrorResponseHandler$JsonContent.parseJsonContent(JsonErrorResponseHandler.java:178)
    at com.amazonaws.http.JsonErrorResponseHandler$JsonContent.<init>(JsonErrorResponseHandler.java:169)
    at com.amazonaws.http.JsonErrorResponseHandler$JsonContent.createJsonContent(JsonErrorResponseHandler.java:158)
    at com.amazonaws.http.JsonErrorResponseHandler.handle(JsonErrorResponseHandler.java:65)
    at com.amazonaws.http.JsonErrorResponseHandler.handle(JsonErrorResponseHandler.java:37)
    at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1355)
    at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:939)
    at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:714)
    at com.amazonaws.http.AmazonHttpClient.doExecute(AmazonHttpClient.java:465)
    at com.amazonaws.http.AmazonHttpClient.executeWithTimer(AmazonHttpClient.java:427)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:376)
    at com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient.doInvoke(AmazonKinesisFirehoseClient.java:1005)
    at com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient.invoke(AmazonKinesisFirehoseClient.java:975)
    at com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient.putRecordBatch(AmazonKinesisFirehoseClient.java:832)
    at com.amazon.kinesis.streaming.agent.tailing.FirehoseSender.attemptSend(Unknown Source)
    at com.amazon.kinesis.streaming.agent.tailing.AbstractSender.sendBuffer(Unknown Source)
    at com.amazon.kinesis.streaming.agent.tailing.SimplePublisher.sendBufferSync(Unknown Source)
    at com.amazon.kinesis.streaming.agent.tailing.AsyncPublisher.access$001(Unknown Source)
    at com.amazon.kinesis.streaming.agent.tailing.AsyncPublisher$1.run(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.lang.Thread.run(Unknown Source)
```