### PR TITLE
synchronize "dist" with file name for Redhat vs RedHat

### DIFF
--- a/setup
+++ b/setup
@@ -14,7 +14,7 @@ if [[ -f /etc/lsb-release ]]; then
 elif [[ -f /etc/debian_version ]]; then
   dist=Debian
 else
-  dist=Redhat
+  dist=RedHat
 fi
 
 # Tell the user what OS we detected


### PR DESCRIPTION
the file is named bin/aws-kinesis-agent.RedHat
but the original code with dist= Redhat  will let ./bin/${daemon_name}.${dist} go for bin/aws-kinesis-agent.Redhat
and will have an error of "No such file or directory"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
