### PR TITLE
Fixing the classpath issues for jackson jar

### DIFF
--- a/setup
+++ b/setup
@@ -14,7 +14,7 @@ if [[ -f /etc/lsb-release ]]; then
 elif [[ -f /etc/debian_version ]]; then
   dist=Debian
 else
-  dist=Redhat
+  dist=RedHat
 fi
 
 # Tell the user what OS we detected
@@ -105,8 +105,8 @@ download_dependencies() {
                   com.amazonaws:aws-java-sdk-cloudwatch:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-sts:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-ec2:${aws_java_sdk_version} \
-                  com.fasterxml.jackson.core:jackson-annotations:2.6.3 \
-                  com.fasterxml.jackson.core:jackson-core:2.6.3 \
+                  com.fasterxml.jackson.core:jackson-annotations:2.9.3 \
+                  com.fasterxml.jackson.core:jackson-core:2.9.3 \
                   com.fasterxml.jackson.core:jackson-databind:2.9.6 \
                   com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6 \
                   com.google.code.findbugs:jsr305:3.0.1 \


### PR DESCRIPTION
*Issue #, if available:*
1. 

-- Unit aws-kinesis-agent.service has begun starting up.
Dec 21 19:23:36 ip-172-16-1-38.ec2.internal runuser[17587]: pam_unix(runuser:session): session opened for user aws-kinesis-agent-user by (uid=0)
Dec 21 19:23:36 ip-172-16-1-38.ec2.internal runuser[17587]: pam_unix(runuser:session): session closed for user aws-kinesis-agent-user
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: Initialization logs can be found in /tmp/aws-kinesis-agent.20181221192336.initlog
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: Exception in thread "main" java.lang.NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonMerge
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector.<clinit>(JacksonAnnotationI
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.fasterxml.jackson.databind.ObjectMapper.<clinit>(ObjectMapper.java:291)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.amazon.kinesis.streaming.agent.config.Configuration.get(Configuration.java:77)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.amazon.kinesis.streaming.agent.config.Configuration.get(Configuration.java:64)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.amazon.kinesis.streaming.agent.Agent.readConfigurationFile(Agent.java:122)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.amazon.kinesis.streaming.agent.Agent.tryReadConfigurationFile(Agent.java:132)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at com.amazon.kinesis.streaming.agent.Agent.main(Agent.java:58)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.annotation.JsonMerge
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: ... 7 more
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal systemd[1]: aws-kinesis-agent.service: control process exited, code=exited status=1
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal aws-kinesis-agent[17580]: [34B blob data]
Dec 21 19:23:38 ip-172-16-1-38.ec2.internal systemd[1]: Failed to start LSB: Daemon for Amazon Kinesis Agent..
-- Subject: Unit aws-kinesis-agent.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- Unit aws-kinesis-agent.service has failed.
--
-- The result is failed.

2.
Getting the below error while running the setup script.
install: cannot stat ‘./bin/aws-kinesis-agent.Redhat’: No such file or directory

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
