### PR TITLE
Fix dist name to be consistent with filename for dynamic script

### DIFF
--- a/setup
+++ b/setup
@@ -14,7 +14,7 @@ if [[ -f /etc/lsb-release ]]; then
 elif [[ -f /etc/debian_version ]]; then
   dist=Debian
 else
-  dist=Redhat
+  dist=RedHat
 fi
 
 # Tell the user what OS we detected


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

 Fixes a typo that caused build to fail on RedHat distributions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
