### PR TITLE
Fix CSV parsing to handle nested comma delimiter inside quotes by using Apache Commons CSV.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,18 +65,23 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
-          <version>2.8.11</version>
+          <version>2.9.10</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <version>2.8.11</version>
+          <version>2.9.10</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
           <version>2.9.10.3</version>
         </dependency>
+        <dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-csv</artifactId>
+		    <version>1.8</version>
+		</dependency>
         <dependency>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>

--- a/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
@@ -54,7 +54,7 @@ public class DataConverterTest {
             put("customFieldNames", Arrays.asList("column1", "column2", "column3", "column4"));
         }});
         final IDataConverter converter = new CSVToJSONDataConverter(config);
-        final String dataStr = "value1, value2,valu\ne3,    value4\n";
+        final String dataStr = "value1, value2,\"valu\ne3\",    value4\n";
         final String expectedStr = "{\"column1\":\"value1\",\"column2\":\" value2\",\"column3\":\"valu\\ne3\",\"column4\":\"    value4\"}\n";
         verifyDataConversion(converter, dataStr.getBytes(), expectedStr.getBytes()); 
         
@@ -64,7 +64,11 @@ public class DataConverterTest {
         
         final String dataStrMoreThanColumns = "value1,value2,value3,value4,value5\n";
         final String expectedStrMoreThanColumns = "{\"column1\":\"value1\",\"column2\":\"value2\",\"column3\":\"value3\",\"column4\":\"value4\"}\n";
-        verifyDataConversion(converter, dataStrMoreThanColumns.getBytes(), expectedStrMoreThanColumns.getBytes()); 
+        verifyDataConversion(converter, dataStrMoreThanColumns.getBytes(), expectedStrMoreThanColumns.getBytes());
+        
+        final String dataStrEmbeddedComma = "value1,\"val,ue2\",value3,value4\n";
+        final String expectedStrEmbeddedComma = "{\"column1\":\"value1\",\"column2\":\"val,ue2\",\"column3\":\"value3\",\"column4\":\"value4\"}\n";
+        verifyDataConversion(converter, dataStrEmbeddedComma.getBytes(), expectedStrEmbeddedComma.getBytes());
     }
     
     @SuppressWarnings("serial")


### PR DESCRIPTION
This is a fix for issue #199 

https://github.com/awslabs/amazon-kinesis-agent/issues/199

This code fix replaces the custom CSV parsing done via string manipulation with the very flexible Apache Commons CSV project.

An additional unit test is added to validate the nested comma problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
