### PR TITLE
add kinesis.region config option

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/AgentContext.java
+++ b/src/com/amazon/kinesis/streaming/agent/AgentContext.java
@@ -41,6 +41,8 @@ import com.amazon.kinesis.streaming.agent.tailing.FileFlowFactory;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
@@ -176,6 +178,8 @@ public class AgentContext extends AgentConfiguration implements IMetricsContext 
                     getAwsCredentialsProvider(), getAwsClientConfiguration());
             if (!Strings.isNullOrEmpty(kinesisEndpoint()))
             	kinesisClient.setEndpoint(kinesisEndpoint());
+            if (!Strings.isNullOrEmpty(kinesisRegion()))
+                kinesisClient.setRegion(Region.getRegion(Regions.fromName(kinesisRegion())));
         }
         return kinesisClient;
     }

--- a/src/com/amazon/kinesis/streaming/agent/config/AgentConfiguration.java
+++ b/src/com/amazon/kinesis/streaming/agent/config/AgentConfiguration.java
@@ -48,6 +48,7 @@ public class AgentConfiguration extends Configuration {
     public static final String ASSUME_ROLE_EXTERNAL_ID = "assumeRoleExternalId";
     public static final String SHUTDOWN_TIMEOUT_MILLIS_KEY = "shutdownTimeoutMillis";
     public static final String ENDPOINT_KEY = "endpoint";
+    public static final String REGION_KEY = "region";
 
     public AgentConfiguration(Map<String, Object> config) {
         super(config);
@@ -175,6 +176,10 @@ public class AgentConfiguration extends Configuration {
     	return this.readString("kinesis." + ENDPOINT_KEY, null);
     }
     
+    public String kinesisRegion() {
+        return this.readString("kinesis." + REGION_KEY, null);
+    }
+
     public String firehoseEndpoint() {
         return this.readString("firehose." + ENDPOINT_KEY, null);
     }


### PR DESCRIPTION
*Issue #, if available:* #207 

*Description of changes:*
This change adds a new configuration value named `kinesis.region` which allows the user to explicitly configure the region that kinesis should use. As explained in #207, `AWS_DEFAULT_REGION` is not sufficient as it gets overridden by some magic in the aws client that parses what it thinks is a region from the endpoint url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
