### PR TITLE
travis-ci explicitly use openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 sudo: required
 install:
   - true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* specify openjdk8 so travis-ci doesn't default to the unsupported java 11.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
