### PR TITLE
Implements handling globs in directory component

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -1,14 +1,14 @@
 /*
  * Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Amazon Software License (the "License").
- * You may not use this file except in compliance with the License. 
+ * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/asl/
- *  
- * or in the "license" file accompanying this file. 
- * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 package com.amazon.kinesis.streaming.agent.tailing;
@@ -32,67 +32,134 @@ import com.google.common.collect.ImmutableList;
 /**
  * Specification of the file(s) to be tailed.
  */
-@EqualsAndHashCode(exclude = { "pathMatcher" })
+@EqualsAndHashCode(exclude = {"pathMatcher"})
 public class SourceFile {
-    @Getter private final FileFlow<?> flow;
-    @Getter private final Path directory;
-    @Getter private final Path filePattern;
+    @Getter
+    private final FileFlow<?> flow;
+    @Getter
+    private final Path directory;
+    @Getter
+    private final Path filePattern;
     private final PathMatcher pathMatcher;
 
     public SourceFile(FileFlow<?> flow, String filePattern) {
         this.flow = flow;
-        // fileName
+
         Preconditions.checkArgument(!filePattern.endsWith("/"), "File name component is empty!");
         Path filePath = FileSystems.getDefault().getPath(filePattern);
-        // TODO: this does not handle globs in directory component: e.g. /opt/*/logs/app.log, /opt/**/app.log*
-        this.directory = filePath.getParent();
+
+        this.directory = findNotGlobParent(filePath);
+
         validateDirectory(this.directory);
-        this.filePattern = filePath.getFileName();
-        this.pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + this.filePattern.toString());
+
+        // Absolute pattern
+        this.filePattern = this.directory.relativize(filePath);
+
+        this.pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + this.directory.resolve(this.filePattern).toString());
+    }
+
+    private boolean isGlobName(String pathPart) {
+        return pathPart.matches(".*(?<!\\\\)\\*.*")
+                || pathPart.matches(".*(?<!\\\\)\\?.*")
+                || pathPart.matches(".*(?<!\\\\)\\[.*");
+    }
+
+    private boolean isGlobName(Path pathPart, int index) {
+        return isGlobName(pathPart.getName(index).toString());
+    }
+
+    private Path findNotGlobParent(Path filePath) {
+        int nameCount = filePath.getNameCount();
+
+        if (nameCount <= 1 || isGlobName(filePath, 0))
+            return filePath.getRoot();
+
+        for (int i = 0; i < nameCount; ++i) { // walk through directories
+            if (isGlobName(filePath, i)) {
+                return filePath.getRoot().resolve(filePath.subpath(0, i));
+            }
+        }
+        return filePath.getParent();
     }
 
     /**
-     * @return List of {@link Path} objects contained in the given directory
-     *          and that match the file name pattern, sorted by {@code lastModifiedTime}
-     *          descending (newest at the top). An empty list is returned if
-     *          {@link #directory} does not exist, or if there are no files
-     *          that match the pattern.
+     * @return List of {@link Path} objects contained in the given directory and subdirectories
+     * and that match the file path pattern, sorted by {@code lastModifiedTime}
+     * descending (newest at the top). An empty list is returned if
+     * {@link #directory} does not exist, or if there are no files
+     * that match the pattern.
      * @throws IOException If there was an error reading the directory or getting
-     *          the {@code lastModifiedTime} of a directory. Note that if
-     *          the {@link #directory} doesn't exist no exception will be thrown
-     *          but an empty list is returned instead.
+     *                     the {@code lastModifiedTime} of a directory. Note that if
+     *                     the {@link #directory} doesn't exist no exception will be thrown
+     *                     but an empty list is returned instead.
      */
     public TrackedFileList listFiles() throws IOException {
-        if(!Files.exists(this.directory))
+        return listFilesImpl(this.directory);
+    }
+
+    /**
+     * @return List of {@link Path} objects contained in {@code directory} and subdirectories
+     * and that match the file path pattern, sorted by {@code lastModifiedTime}
+     * descending (newest at the top). An empty list is returned if
+     * {@link #directory} does not exist, or if there are no files
+     * that match the pattern.
+     * @throws IOException If there was an error reading the directory or getting
+     *                     the {@code lastModifiedTime} of a directory. Note that if
+     *                     the {@link #directory} doesn't exist no exception will be thrown
+     *                     but an empty list is returned instead.
+     */
+    private TrackedFileList listFilesImpl(Path directory) throws IOException {
+        if (!Files.exists(directory))
             return TrackedFileList.emptyList();
 
         List<TrackedFile> files = new ArrayList<>();
-        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(this.directory)) {
-            for (Path p : directoryStream) {
-                if (this.pathMatcher.matches(p.getFileName()) && validateFile(p)) {
-                    files.add(new TrackedFile(flow, p));
+
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory)) {
+            for (Path path : directoryStream) {
+                if (Files.isDirectory(path)) {
+                    files.addAll(listFilesImpl(path));
+                } else if (this.pathMatcher.matches(path) && validateFile(path)) {
+                    files.add(new TrackedFile(flow, path));
                 }
             }
         }
-        // sort the files by decsending last modified time and return
+        // sort the files by descending last modified time and return
         Collections.sort(files, new TrackedFile.NewestFirstComparator());
         return new TrackedFileList(files);
     }
 
     /**
      * @return The number of files on the file system that match the given input
-     *         pattern. More lightweight than {@link #listFiles()}.
+     * pattern. More lightweight than {@link #listFiles()}.
      * @throws IOException If there was an error reading the directory or getting
-     *          the {@code lastModifiedTime} of a directory. Note that if
-     *          the {@link #directory} doesn't exist no exception will be thrown
-     *          but {@code 0} is returned instead.
+     *                     the {@code lastModifiedTime} of a directory. Note that if
+     *                     the {@link #directory} doesn't exist no exception will be thrown
+     *                     but {@code 0} is returned instead.
      */
     public int countFiles() throws IOException {
+        return countFilesImpl(this.directory);
+    }
+
+    /**
+     * The number of files in directory and subdirectories on the file system that match the given input
+     * pattern.
+     *
+     * @param directory Directory
+     * @return The number of files in {@code directory} and subdirectories on the file system that match the given input
+     * pattern.
+     * @throws IOException If there was an error reading the directory or getting
+     *                     the {@code lastModifiedTime} of a directory. Note that if
+     *                     the {@code directory} doesn't exist no exception will be thrown
+     *                     but {@code 0} is returned instead.
+     */
+    private int countFilesImpl(Path directory) throws IOException {
         int count = 0;
-        if(Files.exists(this.directory)) {
-            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(this.directory)) {
-                for (Path p : directoryStream) {
-                    if (this.pathMatcher.matches(p.getFileName()) && validateFile(p)) {
+        if (Files.exists(directory)) {
+            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory)) {
+                for (Path path : directoryStream) {
+                    if (Files.isDirectory(path)) {
+                        count += countFilesImpl(path);
+                    } else if (this.pathMatcher.matches(path) && validateFile(path)) {
                         ++count;
                     }
                 }
@@ -103,7 +170,7 @@ public class SourceFile {
 
     @Override
     public String toString() {
-        return this.directory + "/" + this.filePattern;
+        return this.directory.resolve(this.filePattern).toString();
     }
 
     /**
@@ -113,22 +180,21 @@ public class SourceFile {
      */
     private void validateDirectory(Path dir) {
         Preconditions.checkArgument(dir != null, "Directory component is empty!");
-        // TODO: validate that the directory component has no glob characters
     }
-    
+
     /**
      * Make sure to ignore invalid file for streaming
      * e.g. well known compressed file extensions
      * @param file
      */
     private boolean validateFile(Path file) {
-        List<String> ignoredExtensions = ImmutableList.of(".gz", ".bz2", ".zip"); 
-        
+        List<String> ignoredExtensions = ImmutableList.of(".gz", ".bz2", ".zip");
+
         for (String extension : ignoredExtensions) {
             if (file.toString().toLowerCase().endsWith(extension))
                 return false;
         }
-        
+
         return true;
     }
 }

--- a/tst/com/amazon/kinesis/streaming/agent/testing/TestUtils.java
+++ b/tst/com/amazon/kinesis/streaming/agent/testing/TestUtils.java
@@ -524,6 +524,7 @@ public final class TestUtils {
             Path fname = getTempFilePathWithName(name);
             Preconditions.checkState(!Files.exists(fname), "File already exists: " + fname);
             try {
+                Files.createDirectories(fname.getParent());
                 Files.createFile(fname);
             } catch (IOException e) {
                 throw Throwables.propagate(e);


### PR DESCRIPTION
*Issue #172*

*Description of changes:*

Add support of [glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns in directories. 
Log files:

- `/dir/2020-10-14/log1.txt`
- `/dir/2020-10-12/log2.txt`

can be parsed with `filePattern`
- `/dir/*/log*.txt`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
