### PR TITLE
add date converter feature

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/processing/exceptions/BadStructureTimeConversionException.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/exceptions/BadStructureTimeConversionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License. 
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/asl/
+ *  
+ * or in the "license" file accompanying this file. 
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.amazon.kinesis.streaming.agent.processing.exceptions;
+
+/**
+ * Exception thrown by ILogParser
+ * 
+ * @author chaocheq
+ *
+ */
+@SuppressWarnings("serial")
+public class BadStructureTimeConversionException extends RuntimeException {
+
+    public BadStructureTimeConversionException(String message) {
+        super(message);
+    }
+
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/exceptions/InputOutPutTimeConversionException.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/exceptions/InputOutPutTimeConversionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License. 
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/asl/
+ *  
+ * or in the "license" file accompanying this file. 
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.amazon.kinesis.streaming.agent.processing.exceptions;
+
+/**
+ * Exception thrown by ILogParser
+ * 
+ * @author chaocheq
+ *
+ */
+@SuppressWarnings("serial")
+public class InputOutPutTimeConversionException extends RuntimeException {
+
+    public InputOutPutTimeConversionException(String message) {
+        super(message);
+    }
+
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/exceptions/WrongTimeZoneTimeConversionException.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/exceptions/WrongTimeZoneTimeConversionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License. 
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/asl/
+ *  
+ * or in the "license" file accompanying this file. 
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.amazon.kinesis.streaming.agent.processing.exceptions;
+
+/**
+ * Exception thrown by ILogParser
+ * 
+ * @author chaocheq
+ *
+ */
+@SuppressWarnings("serial")
+public class WrongTimeZoneTimeConversionException extends RuntimeException {
+
+    public WrongTimeZoneTimeConversionException(String message) {
+        super(message);
+    }
+
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/CSVToJSONDataConverter.java
@@ -15,10 +15,12 @@ package com.amazon.kinesis.streaming.agent.processing.processors;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
+import com.amazon.kinesis.streaming.agent.processing.exceptions.InputOutPutTimeConversionException;
+import com.amazon.kinesis.streaming.agent.processing.exceptions.WrongTimeZoneTimeConversionException;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazon.kinesis.streaming.agent.ByteBuffers;
@@ -46,17 +48,32 @@ import com.amazon.kinesis.streaming.agent.processing.utils.ProcessingUtilsFactor
  *
  */
 public class CSVToJSONDataConverter implements IDataConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CSVToJSONDataConverter.class);
     
     private static String FIELDS_KEY = "customFieldNames";
     private static String DELIMITER_KEY = "delimiter";
     private final List<String> fieldNames;
     private final String delimiter;
     private final IJSONPrinter jsonProducer;
+    private static String TIME_CONVERTER = "timeConverter";
+    private static String FORMATTER_INPUT_KEY = "input";
+    private static String FORMATTER_OUTPUT_KEY = "output";
+    private static String TIMEZONE_KEY = "timezone";
+    private final Map<String, Object> timeColumns;
+
     
     public CSVToJSONDataConverter(Configuration config) {
         fieldNames = config.readList(FIELDS_KEY, String.class);
         delimiter = config.readString(DELIMITER_KEY, ",");
         jsonProducer = ProcessingUtilsFactory.getPrinter(config);
+
+        if (config.containsKey(TIME_CONVERTER)) {
+            Configuration configuration2 = config.readConfiguration(TIME_CONVERTER);
+            timeColumns = configuration2.getConfigMap();
+        } else {
+            timeColumns = new HashMap<String, Object>();
+        }
     }
 
     @Override
@@ -81,7 +98,46 @@ public class CSVToJSONDataConverter implements IDataConverter {
                 throw new DataConversionException("Unable to create the column map", e);
             }
         }
-        
+
+        for (String key : timeColumns.keySet()) {
+            try {
+
+                String timezone = (timeColumns.containsKey(TIMEZONE_KEY)) ?
+                        timeColumns.get(TIMEZONE_KEY).toString()
+                        : null;
+
+                if(timezone!=null && !Arrays.asList(TimeZone.getAvailableIDs()).contains(timezone)) throw new WrongTimeZoneTimeConversionException("Such timezone does not exists");
+
+                Object object = timeColumns.get(key);
+                HashMap<String, String> hashMap = (object instanceof HashMap)
+                        ? (HashMap) object
+                        : new HashMap<String, String>();
+
+                if (recordMap.containsKey(key)) {
+                    if(!hashMap.containsKey(FORMATTER_INPUT_KEY)) throw new InputOutPutTimeConversionException("input is not defined");
+
+                    SimpleDateFormat in = new SimpleDateFormat(hashMap.get(FORMATTER_INPUT_KEY));
+                    Date date = in.parse(recordMap.get(key).toString());
+
+                    if(!hashMap.containsKey(FORMATTER_OUTPUT_KEY)) throw new InputOutPutTimeConversionException("output is not defined");
+
+                    SimpleDateFormat out = new SimpleDateFormat(hashMap.get(FORMATTER_OUTPUT_KEY));
+
+                    if(timezone!=null) out.setTimeZone(TimeZone.getTimeZone(timezone));
+
+                    String formattedDate = out.format(date);
+
+                    recordMap.put(key, formattedDate);
+                }
+            } catch (InputOutPutTimeConversionException e) {
+                throw new DataConversionException(e.getMessage());
+            } catch (WrongTimeZoneTimeConversionException e) {
+                throw new DataConversionException(e.getMessage());
+            } catch (Exception e) {
+                LOGGER.warn("Failed to convert date ", e);
+            }
+        }
+
         String dataJson = jsonProducer.writeAsString(recordMap) + NEW_LINE;
         
         return ByteBuffer.wrap(dataJson.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
added feature to convert time from one format to another.

example of settings in agent.json

```
      "dataProcessingOptions": [
        {
          "optionName": "CSVTOJSON",
          "timeConverter": {
              "timezone": "UTC",
              "timeLogged": {
                "input": "yyyy-MM-dd HH:mm:ssZ",
                "output": "yyyy-MM-dd HH:mm:ss"
              }
          },
```

to enable this feature you need to specify `timeConverter` object in `dataProcessingOptions` section. Next you need to add columns you want to convert to another format. If you specify timezone  - the time will get the new timezone.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
