### PR TITLE
Adds GzipDataConverter to gzip records before sending to kinesis

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/processing/processors/GzipDataConverter.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/processors/GzipDataConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License. 
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/asl/
+ *  
+ * or in the "license" file accompanying this file. 
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.amazon.kinesis.streaming.agent.processing.processors;
+
+import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPOutputStream;
+
+
+
+/**
+ * Compress the data using the gzip codec
+ *
+ * Configuration looks like:
+ * 
+ * {
+ *     "optionName": "GZIPCOMPRESSION"
+ * }
+ * 
+ * @author achaibi
+ *
+ */
+public class GzipDataConverter implements IDataConverter {
+    @Override
+    public ByteBuffer convert(ByteBuffer data) {
+        return toCompressedByteBuffer(data);
+    }
+
+    private ByteBuffer toCompressedByteBuffer(ByteBuffer data) {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(out);
+            gzip.write(data.array());
+            gzip.close();
+            return ByteBuffer.wrap(out.toByteArray());
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
+++ b/src/com/amazon/kinesis/streaming/agent/processing/utils/ProcessingUtilsFactory.java
@@ -26,6 +26,7 @@ import com.amazon.kinesis.streaming.agent.processing.processors.AddEC2MetadataCo
 import com.amazon.kinesis.streaming.agent.processing.processors.AddMetadataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.BracketsDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.CSVToJSONDataConverter;
+import com.amazon.kinesis.streaming.agent.processing.processors.GzipDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.LogToJSONDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.PluggableDataConverter;
 import com.amazon.kinesis.streaming.agent.processing.processors.SingleLineDataConverter;
@@ -49,7 +50,8 @@ public class ProcessingUtilsFactory {
         CSVTOJSON,
         LOGTOJSON,
         ADDBRACKETS,
-        USINGPLUGGIN
+        USINGPLUGGIN,
+        GZIPCOMPRESSION
     }
     
     public static enum LogFormat {
@@ -133,6 +135,8 @@ public class ProcessingUtilsFactory {
                 return new BracketsDataConverter();
             case USINGPLUGGIN:
                 return new PluggableDataConverter(config);
+            case GZIPCOMPRESSION:
+                return new GzipDataConverter();
             default:
                 throw new ConfigurationException(
                         "Specified option is not implemented yet: " + option);

--- a/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import com.amazon.kinesis.streaming.agent.config.Configuration;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -231,14 +232,14 @@ public class DataConverterTest {
         final String dataStr = "This is the data";
         ByteBuffer converted = converter.convert(ByteBuffer.wrap(dataStr.getBytes()));
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (GZIPInputStream gis = new GZIPInputStream(new ByteBufferInputStream(converted))) {
+        try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(converted.array()))) {
             byte[] buffer = new byte[1024];
             int len;
             while ((len = gis.read(buffer)) > 0) {
                 bos.write(buffer, 0, len);
             }
         }
-        System.err.println(bos.toByteArray());
+        Assert.assertEquals(bos.toString(), dataStr);
     }
     
     private void verifyDataConversion(IDataConverter converter, byte[] dataBin, byte[] expectedBin) throws Exception {

--- a/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/processing/processors/DataConverterTest.java
@@ -3,15 +3,22 @@
  */
 package com.amazon.kinesis.streaming.agent.processing.processors;
 
+import com.amazon.kinesis.streaming.agent.ByteBufferInputStream;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.amazon.kinesis.streaming.agent.config.Configuration;
 import com.amazon.kinesis.streaming.agent.processing.interfaces.IDataConverter;
 
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.nio.*;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.zip.GZIPInputStream;
+
+
 
 public class DataConverterTest {
     
@@ -216,6 +223,22 @@ public class DataConverterTest {
         final String dataStr = "This is the data";
         final String expectedStr = "{\"metadata\":{\"foo\":{\"bar\":\"bas\"},\"key\":\"value\"},\"data\":\"This is the data\"}\n";
         verifyDataConversion(converter, dataStr.getBytes(), expectedStr.getBytes()); 
+    }
+
+    @Test
+    public void testGzipDataConverter() throws Exception {
+        final IDataConverter converter = new GzipDataConverter();
+        final String dataStr = "This is the data";
+        ByteBuffer converted = converter.convert(ByteBuffer.wrap(dataStr.getBytes()));
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPInputStream gis = new GZIPInputStream(new ByteBufferInputStream(converted))) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gis.read(buffer)) > 0) {
+                bos.write(buffer, 0, len);
+            }
+        }
+        System.err.println(bos.toByteArray());
     }
     
     private void verifyDataConversion(IDataConverter converter, byte[] dataBin, byte[] expectedBin) throws Exception {


### PR DESCRIPTION
*Issue #, if available:*
Issue [219](https://github.com/awslabs/amazon-kinesis-agent/issues/219)

*Description of changes:*
Adds a GzipDataConverter which compresses the byte buffer!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
