### PR TITLE
Change Java version check error message

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,7 @@
       </condition>
     </target>
     <target name="check-java-version" depends="get-java-version" unless="current.java.version">
-        <fail message="Unsupported Java version: ${ant.java.version}. Make sure that the Java version is 1.8 or greater."/>
+        <fail message="Unsupported Java version: ${ant.java.version}. Make sure that the Java version is 1.8 or between 11 and 17."/>
     </target>
     
     <target name="init">


### PR DESCRIPTION
I was using Java 21. When I tried to install the Kinesis agent, the following error message appeared: 
```
BUILD FAILED.
/home/ubuntu/kinesis-agent-install/amazon-kinesis-agent/build.xml:36: Unsupported Java version: 21. Make sure that the Java version is 1.8 or greater.
```

It would be helpful to modify the error message to clarify support for Java 17 or higher.
