### PR TITLE
Fix sample agent.json to use correct userDefinedCredentialsProvider.classname key

### DIFF
--- a/configuration/example/agent.json
+++ b/configuration/example/agent.json
@@ -5,7 +5,7 @@
   "kinesis.endpoint": "https://kinesis.us-west-2.amazonaws.com",
   "awsAccessKeyId": "ACCESSKEY",
   "awsSecretAccessKey": "SECRETKEY",
-  "userDefinedCredentialsProvider.className":"com.amazonaws.samples.NewCustomCredentialsProvider",
+  "userDefinedCredentialsProvider.classname":"com.amazonaws.samples.NewCustomCredentialsProvider",
   "userDefinedCredentialsProvider.location":"/home/ec2-user/NewCustomCredentialsProvider.jar",
   "flows": [
     {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The UserDefinedCredentialsProvided looks for userDefinedCredentialsProvider.classname (lowercase classname) but the provided sample configuration uses mixed case. This commit fixes the example to match what the provider expects https://github.com/awslabs/amazon-kinesis-agent/blob/master/src/com/amazon/kinesis/streaming/agent/UserDefinedCredentialsProvider.java#L23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
