### PR TITLE
Add WebIdentityTokenCredentialsProvider to the Agent chain

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/AgentAWSCredentialsProviderChain.java
+++ b/src/com/amazon/kinesis/streaming/agent/AgentAWSCredentialsProviderChain.java
@@ -19,6 +19,7 @@ import com.amazonaws.auth.ContainerCredentialsProvider;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 public class AgentAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
@@ -27,6 +28,7 @@ public class AgentAWSCredentialsProviderChain extends AWSCredentialsProviderChai
                 new AgentAWSCredentialsProvider(config),
                 new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
+                new WebIdentityTokenCredentialsProvider(),
                 new ContainerCredentialsProvider(),
                 new ProfileCredentialsProvider(),
                 new InstanceProfileCredentialsProvider());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add WebIdentityTokenCredentialsProvider to the Agent chain. This is needed for [IRSA roles](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html) to work and is already included in the DefaultAWSCredentialsProviderChain in the AWS SDK https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java#L60

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
