### PR TITLE
upgrade jackson databind dependency

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,10 @@
           <equals arg1="${ant.java.version}" arg2="15"/>
           <equals arg1="${ant.java.version}" arg2="16"/>
           <equals arg1="${ant.java.version}" arg2="17"/>
+          <equals arg1="${ant.java.version}" arg2="18"/>
+          <equals arg1="${ant.java.version}" arg2="19"/>
+          <equals arg1="${ant.java.version}" arg2="20"/>
+          <equals arg1="${ant.java.version}" arg2="21"/>
         </or>
       </condition>
     </target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>amazon-kinesis-agent</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Agent</name>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
     <description>Amazon Kinesis Agent runs on customer hosts and continuously monitors a set of log files and sends new data to the Amazon Kinesis Stream and Amazon Kinesis Firehose services in near-real-time.</description>
     <url>https://aws.amazon.com/kinesis</url>
 
@@ -65,27 +65,22 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
-          <version>2.10.3</version>
+          <version>2.17.2</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <version>2.10.3</version>
+          <version>2.17.2</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>[2.10.5.1,)</version>
+          <version>2.17.2</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-cbor</artifactId>
-          <version>2.10.3</version>
-        </dependency>
-        <dependency>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
-          <artifactId>jackson-dataformat-xml</artifactId>
-          <version>2.10.3</version>
+          <version>2.17.2</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.findbugs</groupId>

--- a/setup
+++ b/setup
@@ -105,11 +105,10 @@ download_dependencies() {
                   com.amazonaws:aws-java-sdk-cloudwatch:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-sts:${aws_java_sdk_version} \
                   com.amazonaws:aws-java-sdk-ec2:${aws_java_sdk_version} \
-                  com.fasterxml.jackson.core:jackson-annotations:2.10.3\
-                  com.fasterxml.jackson.core:jackson-core:2.10.3 \
-                  com.fasterxml.jackson.core:jackson-databind:2.10.5.1 \
-                  com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.3 \
-                  com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.10.3 \
+                  com.fasterxml.jackson.core:jackson-annotations:2.17.2\
+                  com.fasterxml.jackson.core:jackson-core:2.17.2 \
+                  com.fasterxml.jackson.core:jackson-databind:2.17.2 \
+                  com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.17.2 \
                   com.google.code.findbugs:jsr305:3.0.1 \
                   com.google.guava:guava:29.0-jre \
                   org.apache.httpcomponents:httpclient:4.5.13 \


### PR DESCRIPTION
Upgrading Jackson-databind dependency to 2.17.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
