### PR TITLE
Bugfix for setting kinesis.region and kinesis.endpoint in config

### DIFF
--- a/tst/com/amazon/kinesis/streaming/agent/tailing/KinesisSenderTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/KinesisSenderTest.java
@@ -107,7 +107,7 @@ public class KinesisSenderTest extends TailingTestBase {
             }
         });
         context = Mockito.spy(context);
-        Mockito.when(context.getKinesisClient()).thenReturn(kinesisClient);
+        Mockito.doReturn(kinesisClient).when(context).getKinesisClient();
         KinesisSender sender = new KinesisSender(context, flow);
         List<KinesisRecord> recordsInBuffer = Lists.newArrayList(testBuffer);
         BufferSendResult<KinesisRecord> result = sender.sendBuffer(testBuffer);
@@ -153,7 +153,7 @@ public class KinesisSenderTest extends TailingTestBase {
             }
         });
         context = Mockito.spy(context);
-        Mockito.when(context.getKinesisClient()).thenReturn(kinesisClient);
+        Mockito.doReturn(kinesisClient).when(context).getKinesisClient();
         KinesisSender sender = new KinesisSender(context, flow);
         for(int i = 0; i < successiveFailedRecords.length; ++i) {
             Assert.assertTrue(successiveFailedRecords[i].length > 0, "Failed records array cannot be empty in this test!");
@@ -185,7 +185,7 @@ public class KinesisSenderTest extends TailingTestBase {
         Mockito.when(kinesisClient.putRecords(Mockito.any(PutRecordsRequest.class))).
             thenThrow(AmazonServiceException.class);
         context = Mockito.spy(context);
-        Mockito.when(context.getKinesisClient()).thenReturn(kinesisClient);
+        Mockito.doReturn(kinesisClient).when(context).getKinesisClient();
         KinesisSender sender = new KinesisSender(context, flow);
         sender.sendBuffer(testBuffer);
     }


### PR DESCRIPTION
*Issue #, if available:*
#194 
*Description of changes:*
When setting the region and endpoint in the config with values `kinesis.endpoint` and `kinesis.region`, the region would override the endpoint. The correct way of setting both a region and endpoint is described in https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html with `EndpointConfiguration`. This change also ensures that users who were using this functioanlity by only supplying `kinesis.endpoint` will have the same backwards compatible behavior with this commit, even though the behavior may be erroneous. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
