### PR TITLE
Fix file-tailer race that wedges the tailer in an unrecoverable error loop

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFileTracker.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFileTracker.java
@@ -287,7 +287,19 @@ public class SourceFileTracker {
             initializeCurrentFile(newSnapshot);
             currentFileTracked = false;
         } else {
-            currentFileTracked = updateCurrentFile(newSnapshot);
+            try {
+                currentFileTracked = updateCurrentFile(newSnapshot);
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                // The tracker's internal state is inconsistent (e.g. currentOpenFile
+                // is no longer contained in currentSnapshot). Left alone, this throws
+                // on every subsequent refresh and wedges the tailer in a permanent
+                // error loop with no self-recovery. Reset to the no-current-file state
+                // so the next refresh re-initializes from a freshly listed snapshot
+                // instead of looping forever.
+                LOGGER.error("{}: File tracker state is inconsistent; resetting tailing to recover.", flow.getSourceFile(), e);
+                stopTailing(newSnapshot);
+                currentFileTracked = false;
+            }
         }
         lastRefreshTimestamp = System.currentTimeMillis();
         return currentFileTracked;
@@ -377,18 +389,29 @@ public class SourceFileTracker {
 
     protected void resumeTailingRotatedFileWithNewId(TrackedFileList newSnapshot, int index) throws IOException {
         long offset = currentOpenFile.getCurrentOffset();  // note: FileChannel.position() does not change if underlying file was truncated
+        // Open the new file BEFORE mutating any tracker state. If the file was
+        // deleted since the snapshot was listed (file-rotation race), open() throws
+        // and we leave currentOpenFile/currentSnapshot untouched and consistent, so
+        // the next refresh can retry cleanly.
+        TrackedFile newFile = newSnapshot.get(index);
+        newFile.open(offset);
         closeCurrentFileIfOpen();
-        currentOpenFile = newSnapshot.get(index);
-        currentOpenFile.open(offset);
+        currentOpenFile = newFile;
         currentOpenFileIndex = index;
         LOGGER.trace("Resumed tailing file (index {}): {}", currentOpenFileIndex, currentOpenFile);
         updateSnapshot(newSnapshot, index);
     }
 
     protected void startTailingNewFile(TrackedFileList newSnapshot, int index) throws IOException {
+        // Open the new file BEFORE mutating any tracker state. If the file was
+        // deleted since the snapshot was listed (file-rotation race), open() throws
+        // and we leave currentOpenFile/currentSnapshot untouched and consistent, so
+        // the next refresh can retry cleanly instead of wedging the tailer in a
+        // permanent error loop.
+        TrackedFile newFile = newSnapshot.get(index);
+        newFile.open(0);
         closeCurrentFileIfOpen();
-        currentOpenFile = newSnapshot.get(index);
-        currentOpenFile.open(0);
+        currentOpenFile = newFile;
         currentOpenFileIndex = index;
         LOGGER.trace("Started tailing new file (index {}): {}", currentOpenFileIndex, currentOpenFile);
         updateSnapshot(newSnapshot, index);

--- a/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTrackerTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTrackerTest.java
@@ -27,6 +27,7 @@ import com.amazon.kinesis.streaming.agent.tailing.FileFlowFactory;
 import com.amazon.kinesis.streaming.agent.tailing.FileId;
 import com.amazon.kinesis.streaming.agent.tailing.SourceFileTracker;
 import com.amazon.kinesis.streaming.agent.tailing.TrackedFile;
+import com.amazon.kinesis.streaming.agent.tailing.TrackedFileList;
 import com.amazon.kinesis.streaming.agent.tailing.checkpoints.FileCheckpoint;
 import com.amazon.kinesis.streaming.agent.tailing.testing.CopyFileRotator;
 import com.amazon.kinesis.streaming.agent.tailing.testing.FileRotator;
@@ -47,9 +48,13 @@ public class SourceFileTrackerTest extends TailingTestBase {
 
     protected TestableSourceFileTracker getTracker(FileRotator rotator) throws IOException {
         // create the tracker for these files
-        Configuration flowConfig = new Configuration(getTestFlowConfig(rotator.getInputFileGlob()));
-        FileFlow<?> flow = new FileFlowFactory().getFileFlow(context, flowConfig);
+        FileFlow<?> flow = getFlow(rotator);
         return new TestableSourceFileTracker(rotator, flow, context);
+    }
+
+    protected FileFlow<?> getFlow(FileRotator rotator) throws IOException {
+        Configuration flowConfig = new Configuration(getTestFlowConfig(rotator.getInputFileGlob()));
+        return new FileFlowFactory().getFileFlow(context, flowConfig);
     }
 
     @DataProvider(name="rotators")
@@ -345,6 +350,108 @@ public class SourceFileTrackerTest extends TailingTestBase {
 
         // validate that the initial channel was closed
         tracker.assertRememberedFileWasClosed();
+    }
+
+    /**
+     * Regression test for a file-rotation race where the fallback file is deleted
+     * between {@code listFiles()} and {@code open()}. Before the fix,
+     * {@code startTailingNewFile} reassigned {@code currentOpenFile} before opening,
+     * so when {@code open()} threw the tracker was left with {@code currentOpenFile}
+     * no longer contained in {@code currentSnapshot}. Every subsequent refresh then
+     * threw {@code IllegalArgumentException} ("Current file is not contained in
+     * current snapshot!") forever, with no self-recovery. This test simulates the
+     * race and asserts the tracker recovers on later refreshes.
+     */
+    @Test
+    public void testRaceWhenFallbackFileDeletedDuringOpenIsRecoverable() throws IOException {
+        // Use the create-new-file rotation mode: it produces distinct, on-demand
+        // files (matching the real-world scenario this race was observed in) and
+        // lets us delete individual files without disturbing rotator bookkeeping.
+        FileRotator rotator = new CreateFileRotatorFactory().create();
+        rotator.rotate(2);
+        FileFlow<?> flow = getFlow(rotator);
+
+        // One-shot injection: simulate the file vanishing between the directory
+        // listing and the open() that startTailingNewFile performs on it.
+        final boolean[] injectRace = { false };
+        TestableSourceFileTracker tracker = new TestableSourceFileTracker(rotator, flow, context) {
+            @Override
+            protected void startTailingNewFile(TrackedFileList newSnapshot, int index) throws IOException {
+                if (injectRace[0]) {
+                    injectRace[0] = false;
+                    moveFileToTrash(newSnapshot.get(index).getPath());
+                }
+                super.startTailingNewFile(newSnapshot, index);
+            }
+        };
+        tracker.initialize();
+        Assert.assertNotNull(tracker.getCurrentOpenFile());
+        TrackedFile originalOpenFile = tracker.getCurrentOpenFile();
+
+        // Delete the current open file so the next refresh falls back to the other
+        // file, then make that fallback vanish during open() (the race).
+        moveFileToTrash(rotator.getFile(0));
+        injectRace[0] = true;
+        try {
+            tracker.refresh();
+        } catch (IOException expected) {
+            // The vanished-file open() surfaces as a transient IOException; the agent
+            // logs and retries. The bug being fixed is the PERMANENT failure that
+            // followed it, not this transient error.
+        }
+
+        // Fix A: state was not corrupted by the failed open(), so the next refresh
+        // must NOT throw IllegalArgumentException.
+        tracker.refresh();
+
+        // With both files gone the tracker should have cleanly stopped tailing.
+        Assert.assertNull(tracker.getCurrentOpenFile());
+
+        // And it self-recovers: once a new file appears it resumes tailing.
+        rotator.rotate();
+        tracker.refresh();
+        Assert.assertNotNull(tracker.getCurrentOpenFile());
+        Assert.assertTrue(tracker.getCurrentOpenFile().isOpen());
+        Assert.assertNotSame(tracker.getCurrentOpenFile(), originalOpenFile);
+    }
+
+    /**
+     * Regression test for the recovery guard: if the tracker's internal state ever
+     * becomes inconsistent and {@code updateCurrentFile} throws an
+     * {@code IllegalArgumentException}/{@code IllegalStateException}, {@code refresh()}
+     * must reset to a recoverable state rather than propagating the exception on every
+     * poll forever.
+     */
+    @Test
+    public void testRefreshRecoversFromInconsistentTrackerState() throws IOException {
+        FileRotator rotator = new CreateFileRotatorFactory().create();
+        rotator.rotate(2);
+        FileFlow<?> flow = getFlow(rotator);
+
+        final boolean[] failOnce = { false };
+        SourceFileTracker tracker = new SourceFileTracker(context, flow) {
+            @Override
+            boolean updateCurrentFile(TrackedFileList newSnapshot) throws IOException {
+                if (failOnce[0]) {
+                    failOnce[0] = false;
+                    throw new IllegalArgumentException("Current file is not contained in current snapshot!");
+                }
+                return super.updateCurrentFile(newSnapshot);
+            }
+        };
+        tracker.initialize();
+        Assert.assertNotNull(tracker.getCurrentOpenFile());
+
+        // First refresh hits the simulated inconsistency. It must be swallowed and
+        // the tracker reset to the no-current-file state, not propagated.
+        failOnce[0] = true;
+        tracker.refresh();
+        Assert.assertNull(tracker.getCurrentOpenFile());
+
+        // Subsequent refresh re-initializes from disk and resumes tailing.
+        tracker.refresh();
+        Assert.assertNotNull(tracker.getCurrentOpenFile());
+        Assert.assertTrue(tracker.getCurrentOpenFile().isOpen());
     }
 
     @Test(description = "Test behavior of an open channel when more data is appeneded.")


### PR DESCRIPTION
## Problem

When the file currently being tailed and its only fallback file are both deleted in the window between the directory listing and opening the file, `SourceFileTracker` reassigns `currentOpenFile` *before* `open()` succeeds. When that `open()` then throws (the file is gone), the tracker is left with `currentOpenFile` no longer contained in `currentSnapshot`.

On the next `refresh()`, `TrackedFileRotationAnalyzer`'s precondition (`current.contains(currentOpenFile)`) throws `IllegalArgumentException`, and the FileTailer catches it but does not reset the tracker. Every subsequent poll reproduces the same exception, so the tailer spins in a permanent error loop and ships zero records with no self-recovery short of a JVM restart.

## Fix

- `startTailingNewFile` / `resumeTailingRotatedFileWithNewId` now `open()` the new file **before** mutating any tracker state. A failed `open()` leaves `currentOpenFile`/`currentSnapshot` consistent, so the next refresh retries cleanly.
- `refresh()` now catches invariant-violation exceptions from `updateCurrentFile`, resets to the no-current-file state, and recovers in-process on the next poll instead of looping forever.

## Testing

- New regression tests in `SourceFileTrackerTest` cover the open-race and the recovery guard.
- Full `SourceFileTracker` / `FileTailer` / rotation-analyzer suites pass.
- Verified end-to-end against a live Kinesis stream: before the fix the tailer wedges (thousands of repeated errors, 0 records shipped) after the race; with the fix it recovers and resumes shipping records.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.