### PR TITLE
Emit ConsecutiveProcessingErrors metric for stuck file tailers

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/FileTailer.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/FileTailer.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import org.joda.time.Duration;
@@ -77,9 +78,8 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
     // value indicates the tailer is stuck in an error loop (e.g. it can no longer
     // track or open its input file) and is no longer making progress, which the
     // parse/send throughput metrics cannot distinguish from a healthy idle host.
+    @Getter(AccessLevel.PROTECTED)
     private final AtomicLong consecutiveProcessingErrors = new AtomicLong();
-    // Cumulative count of processRecords() iterations that failed, for context.
-    private final AtomicLong totalProcessingErrors = new AtomicLong();
 
     public FileTailer(AgentContext agentContext,
             FileFlow<R> flow,
@@ -286,7 +286,6 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
             // Iteration completed without error: clear the consecutive-error streak.
             consecutiveProcessingErrors.set(0);
         } catch (Exception e) {
-            totalProcessingErrors.incrementAndGet();
             long consecutive = consecutiveProcessingErrors.incrementAndGet();
             LOGGER.error("{}: Error when processing current input file or when tracking its status (consecutive errors: {}).", serviceName(), consecutive, e);
         }
@@ -486,11 +485,6 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
         }
     }
 
-    @VisibleForTesting
-    long getConsecutiveProcessingErrors() {
-        return consecutiveProcessingErrors.get();
-    }
-
     public Map<String, Object> getMetrics() {
         Map<String, Object> metrics = publisher.getMetrics();
         metrics.putAll(parser.getMetrics());
@@ -498,7 +492,6 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
         metrics.put("FileTailer.BytesBehind", bytesBehind());
         metrics.put("FileTailer.RecordsTruncated", recordsTruncated);
         metrics.put("FileTailer.ConsecutiveProcessingErrors", consecutiveProcessingErrors);
-        metrics.put("FileTailer.TotalProcessingErrors", totalProcessingErrors);
         return metrics;
     }
 }

--- a/src/com/amazon/kinesis/streaming/agent/tailing/FileTailer.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/FileTailer.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.amazon.kinesis.streaming.agent.Agent;
 import com.amazon.kinesis.streaming.agent.AgentContext;
 import com.amazon.kinesis.streaming.agent.IHeartbeatProvider;
+import com.amazon.kinesis.streaming.agent.metrics.IMetricsScope;
 import com.amazon.kinesis.streaming.agent.metrics.Metrics;
 import com.amazon.kinesis.streaming.agent.tailing.checkpoints.FileCheckpoint;
 import com.amazon.kinesis.streaming.agent.tailing.checkpoints.FileCheckpointStore;
@@ -35,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.AbstractScheduledService;
 
@@ -48,6 +50,7 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 public class FileTailer<R extends IRecord> extends AbstractExecutionThreadService implements IHeartbeatProvider {
     private static final int NO_TIMEOUT = -1;
     private static final int MAX_SPIN_WAIT_TIME_MILLIS = 1000;
+    private static final String CONSECUTIVE_PROCESSING_ERRORS_METRIC = "ConsecutiveProcessingErrors";
     private static final Logger LOGGER = LoggerFactory.getLogger(FileTailer.class);
 
     @Getter private final AgentContext agentContext;
@@ -68,6 +71,15 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
 
     private boolean isInitialized = false;
     private final AtomicLong recordsTruncated = new AtomicLong();
+
+    // Number of consecutive processRecords() iterations that failed with an
+    // exception. Reset to 0 on any successful iteration. A persistently elevated
+    // value indicates the tailer is stuck in an error loop (e.g. it can no longer
+    // track or open its input file) and is no longer making progress, which the
+    // parse/send throughput metrics cannot distinguish from a healthy idle host.
+    private final AtomicLong consecutiveProcessingErrors = new AtomicLong();
+    // Cumulative count of processRecords() iterations that failed, for context.
+    private final AtomicLong totalProcessingErrors = new AtomicLong();
 
     public FileTailer(AgentContext agentContext,
             FileFlow<R> flow,
@@ -252,6 +264,9 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
         try {
             if(!updateRecordParser(false)) {
                 LOGGER.trace("{}: There's no file being tailed.", serviceName());
+                // Having no file to tail is a healthy idle state, not an error:
+                // clear any prior error streak.
+                consecutiveProcessingErrors.set(0);
                 return 0;
             }
             processed = processRecordsInCurrentFile();
@@ -268,8 +283,12 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
                     isNewFile = parser.continueParsingWithFile(fileTracker.getCurrentOpenFile());
                 }
             }
+            // Iteration completed without error: clear the consecutive-error streak.
+            consecutiveProcessingErrors.set(0);
         } catch (Exception e) {
-            LOGGER.error("{}: Error when processing current input file or when tracking its status.", serviceName(), e);
+            totalProcessingErrors.incrementAndGet();
+            long consecutive = consecutiveProcessingErrors.incrementAndGet();
+            LOGGER.error("{}: Error when processing current input file or when tracking its status (consecutive errors: {}).", serviceName(), consecutive, e);
         }
         return processed;
     }
@@ -441,9 +460,35 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
             } else if (bytesBehind > 0) {
                 LOGGER.debug(msg);
             }
+            emitProcessingErrorMetrics();
         } catch (Exception e) {
             LOGGER.error("{}: Failed while emitting tailer status.", serviceName(), e);
         }
+    }
+
+    /**
+     * Publishes the tailer's processing-error signal to CloudWatch so it can be
+     * alarmed on directly from agent telemetry. {@code ConsecutiveProcessingErrors}
+     * is a gauge that stays at 0 while the tailer makes progress and climbs while it
+     * is stuck in an error loop, making a wedged tailer distinguishable from a
+     * healthy idle host (whose throughput metrics also read 0).
+     */
+    private void emitProcessingErrorMetrics() {
+        IMetricsScope scope = agentContext.beginScope();
+        scope.addDimension(Metrics.DESTINATION_DIMENSION, flow.getDestination());
+        if (!Strings.isNullOrEmpty(agentContext.getInstanceTag())) {
+            scope.addDimension(Metrics.INSTANCE_DIMENSION, agentContext.getInstanceTag());
+        }
+        try {
+            scope.addCount(CONSECUTIVE_PROCESSING_ERRORS_METRIC, consecutiveProcessingErrors.get());
+        } finally {
+            scope.commit();
+        }
+    }
+
+    @VisibleForTesting
+    long getConsecutiveProcessingErrors() {
+        return consecutiveProcessingErrors.get();
     }
 
     public Map<String, Object> getMetrics() {
@@ -452,6 +497,8 @@ public class FileTailer<R extends IRecord> extends AbstractExecutionThreadServic
         metrics.put("FileTailer.FilesBehind", filesBehind());
         metrics.put("FileTailer.BytesBehind", bytesBehind());
         metrics.put("FileTailer.RecordsTruncated", recordsTruncated);
+        metrics.put("FileTailer.ConsecutiveProcessingErrors", consecutiveProcessingErrors);
+        metrics.put("FileTailer.TotalProcessingErrors", totalProcessingErrors);
         return metrics;
     }
 }

--- a/tst/com/amazon/kinesis/streaming/agent/tailing/FileTailerProcessingErrorMetricTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/FileTailerProcessingErrorMetricTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014-2017 Amazon.com, Inc. All Rights Reserved.
+ */
+package com.amazon.kinesis.streaming.agent.tailing;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.amazon.kinesis.streaming.agent.AgentContext;
+import com.amazon.kinesis.streaming.agent.tailing.checkpoints.FileCheckpointStore;
+import com.amazon.kinesis.streaming.agent.tailing.checkpoints.SQLiteFileCheckpointStore;
+import com.amazon.kinesis.streaming.agent.tailing.testing.FileSender;
+import com.amazon.kinesis.streaming.agent.tailing.testing.FileRotator;
+import com.amazon.kinesis.streaming.agent.tailing.testing.TailingTestBase;
+
+/**
+ * Verifies that {@link FileTailer} tracks the consecutive-processing-error gauge
+ * that backs the agent's stuck-tailer failure metric: it climbs while every
+ * iteration fails (the error-loop signal alarms watch for) and resets to 0 as soon
+ * as the tailer makes progress again or reaches a healthy idle state.
+ */
+public class FileTailerProcessingErrorMetricTest extends TailingTestBase {
+
+    /**
+     * A tailer whose record-processing step can be forced to throw, so we can drive
+     * the error-accounting paths in {@link FileTailer#processRecords()} directly
+     * without standing up the full async publisher/sender machinery.
+     */
+    private static class ControllableFileTailer extends FileTailer<FirehoseRecord> {
+        volatile boolean failNextProcess = false;
+
+        ControllableFileTailer(AgentContext context, FileFlow<FirehoseRecord> flow,
+                AsyncPublisherService<FirehoseRecord> publisher, IParser<FirehoseRecord> parser,
+                FileCheckpointStore checkpoints) throws IOException {
+            super(context, flow, new SourceFileTracker(context, flow), publisher, parser, checkpoints);
+        }
+
+        @Override
+        protected synchronized boolean updateRecordParser(boolean forceRefresh) throws IOException {
+            if (failNextProcess) {
+                throw new IllegalArgumentException("simulated unrecoverable tracker error");
+            }
+            // Pretend there is no file to tail: a clean, no-op iteration.
+            return false;
+        }
+    }
+
+    private ControllableFileTailer createTailer() throws IOException {
+        FileRotator rotator = new CreateFileRotatorFactory().create();
+        rotator.rotate();
+        AgentContext context = getTestAgentContext(rotator.getInputFileGlob());
+        @SuppressWarnings("unchecked")
+        FileFlow<FirehoseRecord> flow = (FileFlow<FirehoseRecord>) context.flows().get(0);
+        FileCheckpointStore checkpoints = new SQLiteFileCheckpointStore(context);
+        IParser<FirehoseRecord> parser = new FirehoseParser(flow, FirehoseConstants.DEFAULT_PARSER_BUFFER_SIZE_BYTES);
+        FileSender<FirehoseRecord> sender = new FileSender.PerfectFileSenderFactory<FirehoseRecord>()
+                .create(context, testFiles.createTempFile());
+        AsyncPublisherService<FirehoseRecord> publisher =
+                new AsyncPublisherService<>(context, flow, checkpoints, sender, context.createSendingExecutor());
+        return new ControllableFileTailer(context, flow, publisher, parser, checkpoints);
+    }
+
+    @Test
+    public void testConsecutiveErrorsClimbWhileStuckAndResetOnRecovery() throws IOException {
+        ControllableFileTailer tailer = createTailer();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+
+        // Every iteration fails: the gauge must climb monotonically (the signal an
+        // alarm fires on when the tailer is wedged in an error loop).
+        tailer.failNextProcess = true;
+        tailer.processRecords();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 1);
+        tailer.processRecords();
+        tailer.processRecords();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 3);
+
+        // The tailer recovers: a clean iteration resets the gauge to 0 so the alarm
+        // clears and a single transient error never lingers.
+        tailer.failNextProcess = false;
+        tailer.processRecords();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+    }
+
+    @Test
+    public void testTransientErrorDoesNotLatchGauge() throws IOException {
+        ControllableFileTailer tailer = createTailer();
+
+        // A single failure followed by a healthy (idle) iteration must leave the
+        // gauge at 0, so transient blips don't trip the alarm.
+        tailer.failNextProcess = true;
+        tailer.processRecords();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 1);
+
+        tailer.failNextProcess = false;
+        tailer.processRecords();
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+    }
+}

--- a/tst/com/amazon/kinesis/streaming/agent/tailing/FileTailerProcessingErrorMetricTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/FileTailerProcessingErrorMetricTest.java
@@ -65,22 +65,22 @@ public class FileTailerProcessingErrorMetricTest extends TailingTestBase {
     @Test
     public void testConsecutiveErrorsClimbWhileStuckAndResetOnRecovery() throws IOException {
         ControllableFileTailer tailer = createTailer();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 0);
 
         // Every iteration fails: the gauge must climb monotonically (the signal an
         // alarm fires on when the tailer is wedged in an error loop).
         tailer.failNextProcess = true;
         tailer.processRecords();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 1);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 1);
         tailer.processRecords();
         tailer.processRecords();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 3);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 3);
 
         // The tailer recovers: a clean iteration resets the gauge to 0 so the alarm
         // clears and a single transient error never lingers.
         tailer.failNextProcess = false;
         tailer.processRecords();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 0);
     }
 
     @Test
@@ -91,10 +91,10 @@ public class FileTailerProcessingErrorMetricTest extends TailingTestBase {
         // gauge at 0, so transient blips don't trip the alarm.
         tailer.failNextProcess = true;
         tailer.processRecords();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 1);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 1);
 
         tailer.failNextProcess = false;
         tailer.processRecords();
-        Assert.assertEquals(tailer.getConsecutiveProcessingErrors(), 0);
+        Assert.assertEquals(tailer.getConsecutiveProcessingErrors().get(), 0);
     }
 }


### PR DESCRIPTION
## Problem

The agent's existing metrics only report progress while the tailer is actively parsing. A tailer wedged in an error loop before it can parse is indistinguishable from a healthy idle host — throughput reads 0 in both cases — so a stuck tailer produces no signal that monitoring can alarm on.

## Change

`FileTailer` now tracks a consecutive processing error gauge: It increments on each `processRecords()` iteration that throws and resets to 0 on any successful or idle iteration. The gauge is published to CloudWatch as `ConsecutiveProcessingErrors` (dimensioned by destination and instance) on the existing status reporting schedule, using the same metrics-scope mechanism as the senders, so a wedged tailer can be alarmed on directly from agent telemetry. A cumulative `TotalProcessingErrors` counter is also exposed in the logged metrics map for context.

## Testing

- New unit test covers the climb-while-stuck and reset-on-recovery behavior.
- Verified end-to-end against live CloudWatch: while a tailer is stuck, the `ConsecutiveProcessingErrors` datapoint climbs across successive reporting periods; it stays at 0 during normal operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.